### PR TITLE
Update CI workflow for build and test process

### DIFF
--- a/.github/workflows/Build and Test Packages.yml
+++ b/.github/workflows/Build and Test Packages.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Test
         # We add --logger trx to generate a machine-readable report
         # We specify a results directory so the upload step knows where to look
-        run: dotnet test src/DLLPickle.Build/DLLPickle.csproj --no-build --verbosity normal --logger "trx;LogFileName=test-results.trx" --results-directory TestResults
+        run: dotnet test src/DLLPickle.Build/DLLPickle.csproj --no-build --verbosity normal --logger "trx;LogFileName=test-results.trx" --results-directory ./TestResults
 
       - name: Upload Test Results
         # This runs even if the 'Test' step fails (which is when you need it most!)
@@ -61,8 +61,9 @@ jobs:
         uses: dorny/test-reporter@v2
         with:
           name: 🚀 Unit Test Results  # Name that appears in GitHub UI
-          path: 'TestResults/*.trx'
+          path: '**/TestResults/*.trx'
           reporter: dotnet-trx
+          token: ${{ steps.generate_token.outputs.token }}
           # This specifically adds the report to the Actions Summary page
           only-summary: 'false'
           list-tests: 'failed'    # Shows a list of specifically which tests failed


### PR DESCRIPTION
<!-- markdownlint-configure-file { "MD012": false } -->
<!--- Provide a general summary of your changes in the Title above -->
# Pull Request

## Description
<!-- Please include a clear description of what your pull request does.
Remember to only include one change (or group of tightly related changes)
per pull request to make review and testing easier. -->

This pull request makes minor improvements to the CI workflow for building and testing packages. The changes ensure that test results are correctly collected from all directories and that the test reporter has the necessary authentication token.

* CI workflow improvements:
  * Updated the `dotnet test` command to specify the `TestResults` directory with a relative path (`./TestResults`) for consistency and clarity.
  * Changed the test results upload step to search for test result files in all subdirectories (`**/TestResults/*.trx`) instead of just the top-level `TestResults` directory, ensuring all results are found.
  * Added a token input to the `dorny/test-reporter` step to provide authentication, improving reliability of report uploads.

## Type of Change

- [ ] 📖 Documentation
- [x] 🪲 Fix
- [ ] 🩹 Patch
- [ ] ⚠️ Security Fix
- [ ] 🚀 Feature
- [ ] 💥 Breaking Change
