### PR TITLE
ci(workflows): Remove unnecessary steps and permissions

### DIFF
--- a/.github/workflows/Build and Test Packages.yml
+++ b/.github/workflows/Build and Test Packages.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - 'src/DLLPickle.Build/**'
       - 'packages.lock.json'
-      - '.github/workflows/ci.yml'
+      - '.github/workflows/Build and Test Packages.yml'
 
 jobs:
   build-and-test:
@@ -18,19 +18,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup MSBuild
+      - name: 👷 Setup MSBuild
         uses: microsoft/setup-msbuild@v2
 
-      - name: Setup .NET
+      - name: 🧑‍💻 Setup .NET
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 
-      - name: Restore dependencies
+      - name: 📦 Restore dependencies
         run: dotnet restore src/DLLPickle.Build/DLLPickle.csproj --force-evaluate
         shell: pwsh
 
-      - name: Build
+      - name: 🏗️ Build
         run: dotnet build src/DLLPickle.Build/DLLPickle.csproj --configuration Release --no-restore
 
       - name: 🛡️ Dependency Review


### PR DESCRIPTION
<!-- markdownlint-configure-file { "MD012": false } -->
<!--- Provide a general summary of your changes in the Title above -->
# Pull Request

## Description
<!-- Please include a clear description of what your pull request does.
Remember to only include one change (or group of tightly related changes)
per pull request to make review and testing easier. -->

This pull request updates the build and test workflow for the project, focusing on simplifying permissions, removing custom GitHub App token logic, and replacing unit test steps with a security scan for dependency review. The workflow steps have been reorganized and clarified for easier maintenance.

Workflow and security improvements:

* Simplified `permissions` to use only `contents: read` and `pull-requests: write`, relying on the default `GITHUB_TOKEN` and removing unnecessary custom token generation.
* Replaced the unit test and test reporting steps with a dependency review security scan using `actions/dependency-review-action@v4`, which automatically uses the default `GITHUB_TOKEN`.

Step organization and clarity:

* Renamed and reorganized workflow steps for clarity, including clearer names and comments for setup, restore, build, and security scan stages. [[1]](diffhunk://#diff-053392bc66879669dcc503ab0a58b2ade898317a2115760b24a56f8b7a3617ebR10-R32) [[2]](diffhunk://#diff-053392bc66879669dcc503ab0a58b2ade898317a2115760b24a56f8b7a3617ebL50-R51)
* Removed custom logic for handling Dependabot and other actors in dependency restoration, now only force-updating the lock file for Dependabot.
* Eliminated artifact upload and test report publishing steps, streamlining the workflow to focus on build and security checks.