### PR TITLE
ci: Update workflow permissions to be able to create a GitHub release

### DIFF
--- a/.github/workflows/Release and Publish.yml
+++ b/.github/workflows/Release and Publish.yml
@@ -283,6 +283,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [analyze, update-version, build-and-test]
 
+    permissions:
+      contents: write
+
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
@@ -503,6 +506,7 @@ jobs:
           "@
 
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $summary
+
 
 
 


### PR DESCRIPTION
<!-- markdownlint-configure-file { "MD012": false } -->
<!--- Provide a general summary of your changes in the Title above -->
# Pull Request

## Description
<!-- Please include a clear description of what your pull request does.
Remember to only include one change (or group of tightly related changes)
per pull request to make review and testing easier. -->

This pull request makes a minor but important update to the GitHub Actions workflow for release and publishing. The main change is the addition of permissions to allow the workflow to write to repository contents, which is necessary for publishing artifacts or updating files during the release process.

Workflow permissions update:

* Added `permissions: contents: write` to the `jobs` section in `.github/workflows/Release and Publish.yml`, enabling the workflow to modify repository contents as part of the release and publish process.

There are no other significant changes in this pull request.

## Type of Change

- [ ] 📖 Documentation
- [x] 🪲 Fix
- [ ] 🩹 Patch
- [ ] ⚠️ Security Fix
- [ ] 🚀 Feature
- [ ] 💥 Breaking Change

## Issue Resolved
<!-- If this PR resolves an issue, enter the issue number here. -->



## Checklist

- [ ] I have reviewed my code for errors and tested it.
- [ ] My pull request does not contain multiple types of changes.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation as necessary.
- [ ] I have read the **CONTRIBUTING** document.

### Testing

If possible, we kindly ask that Pester tests be added for any new or changed functionality.

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
