### PR TITLE
ci: Fix path to publish script

### DIFF
--- a/.github/workflows/Release and Publish.yml
+++ b/.github/workflows/Release and Publish.yml
@@ -453,7 +453,7 @@ jobs:
               exit 1
           }
 
-          $publishResult = & ./.github/scripts/Publish-ToGallery.ps1 `
+          $publishResult = & ./.github/ci-scripts/Publish-ToGallery.ps1 `
             -ModuleDirectory "$($env:MODULE_DIR)" -ApiKey "$($env:PSGALLERY_API_KEY)"
 
           if (-not $publishResult.Success) {
@@ -506,6 +506,7 @@ jobs:
           "@
 
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $summary
+
 
 
 


### PR DESCRIPTION
Added a new workflow for releasing and publishing the DLLPickle module, including version bumping and GitHub release creation.

<!-- markdownlint-configure-file { "MD012": false } -->
<!--- Provide a general summary of your changes in the Title above -->
# Pull Request

## Description
<!-- Please include a clear description of what your pull request does.
Remember to only include one change (or group of tightly related changes)
per pull request to make review and testing easier. -->

This pull request makes a minor update to the release workflow by changing the path to the PowerShell script used for publishing to the gallery.

- The `Publish-ToGallery.ps1` script is now referenced from the `.github/ci-scripts/` directory instead of `.github/scripts/` in the workflow file `.github/workflows/Release and Publish.yml`.

## Type of Change

- [ ] 📖 Documentation
- [x] 🪲 Fix
- [ ] 🩹 Patch
- [ ] ⚠️ Security Fix
- [ ] 🚀 Feature
- [ ] 💥 Breaking Change
