### PR TITLE
fix(ci): Fix modulepath variable in publish script

### DIFF
--- a/.github/workflows/Release and Publish.yml
+++ b/.github/workflows/Release and Publish.yml
@@ -31,7 +31,7 @@ permissions:
 
 env:
   MODULE_NAME: DLLPickle
-  MODULE_DIR: ./src/DLLPickle
+  MODULE_DIR: ./module/DLLPickle
   MANIFEST_PATH: ./src/DLLPickle/DLLPickle.psd1
 
 jobs:
@@ -506,6 +506,7 @@ jobs:
           "@
 
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $summary
+
 
 
 


### PR DESCRIPTION
<!-- markdownlint-configure-file { "MD012": false } -->
<!--- Provide a general summary of your changes in the Title above -->
# Pull Request

## Description
<!-- Please include a clear description of what your pull request does.
Remember to only include one change (or group of tightly related changes)
per pull request to make review and testing easier. -->

This pull request makes a small update to the GitHub Actions workflow configuration for releasing and publishing the `DLLPickle` module. The main change is updating the directory path for the module to reflect its new location.

* Changed the `MODULE_DIR` environment variable in `.github/workflows/Release and Publish.yml` from `./src/DLLPickle` to `./module/DLLPickle`, ensuring the workflow references the correct module directory.

## Type of Change

- [ ] 📖 Documentation
- [x] 🪲 Fix
- [ ] 🩹 Patch
- [ ] ⚠️ Security Fix
- [ ] 🚀 Feature
- [ ] 💥 Breaking Change
