### PR TITLE
ci: Add GitHub Actions workflow for release and publish

### DIFF
--- a/.github/workflows/Release and Publish.yml
+++ b/.github/workflows/Release and Publish.yml
@@ -454,7 +454,7 @@ jobs:
           }
 
           $publishResult = & ./.github/ci-scripts/Publish-ToGallery.ps1 `
-            -ModuleDirectory "$($env:MODULE_DIR)" -ApiKey "$($env:PSGALLERY_API_KEY)"
+            -Path "$($env:MODULE_DIR)" -ApiKey "$($env:PSGALLERY_API_KEY)"
 
           if (-not $publishResult.Success) {
               Write-Error "Publishing failed: $($publishResult.Message)`nError: $($publishResult.ErrorMessage)"
@@ -506,6 +506,7 @@ jobs:
           "@
 
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $summary
+
 
 
 


### PR DESCRIPTION
<!-- markdownlint-configure-file { "MD012": false } -->
<!--- Provide a general summary of your changes in the Title above -->
# Pull Request

## Description
<!-- Please include a clear description of what your pull request does.
Remember to only include one change (or group of tightly related changes)
per pull request to make review and testing easier. -->

This pull request makes a minor update to the release workflow, specifically in the publishing step. The change updates the parameter name used when calling the PowerShell publishing script to match the expected input.

* Publishing workflow update:
  * [`.github/workflows/Release and Publish.yml`](diffhunk://#diff-75a638e121853b07caa24a3c1fe0ace55695d40f423c33a8cbb61dd04f8d42bcL457-R457): Changed the parameter from `-ModuleDirectory` to `-Path` when invoking `Publish-ToGallery.ps1`, ensuring compatibility with the script's expected parameter.
