### PR TITLE
feat: add unique categories for SARIF uploads in security scans

### DIFF
--- a/.github/workflows/Supply-Chain-Security-Scorecards.yml
+++ b/.github/workflows/Supply-Chain-Security-Scorecards.yml
@@ -75,3 +75,5 @@ jobs:
         uses: github/codeql-action/upload-sarif@9e907b5e64f6b83e7804b09294d44122997950d6 # v4.32.3
         with:
           sarif_file: results.sarif
+          # Unique category to distinguish from other security scans
+          category: ossf-scorecards

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -63,5 +63,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@9e907b5e64f6b83e7804b09294d44122997950d6 # v4.32.3
         with:
           sarif_file: results.sarif
+          # Unique category to distinguish from other security scans
+          category: codacy-security-scan
           # Wait for processing to ensure results appear in Security tab
           wait-for-processing: true


### PR DESCRIPTION
<!-- markdownlint-configure-file { "MD012": false } -->
<!--- Provide a general summary of your changes in the Title above -->
# Pull Request

## Description
<!-- Please include a clear description of what your pull request does.
Remember to only include one change (or group of tightly related changes)
per pull request to make review and testing easier. -->

This pull request makes minor updates to GitHub Actions workflow files to improve the categorization of security scan results. The changes add unique categories to SARIF uploads, which helps distinguish between different types of security scans in the GitHub Security tab.

Security scan categorization improvements:

* [`.github/workflows/Supply-Chain-Security-Scorecards.yml`](diffhunk://#diff-3abc255ad08e2ad23ee278f69d542cf1887f6c1ee7dad87b55a069c845cdcf16R78-R79): Added a `category: ossf-scorecards` field to the SARIF upload step to uniquely identify supply chain security scorecard results.
* [`.github/workflows/codacy.yml`](diffhunk://#diff-f0d3530b5eea10fe26ad541e683cfb4072e290804705de6abf6a5b2e80a72f59R66-R67): Added a `category: codacy-security-scan` field to the SARIF upload step to uniquely identify Codacy security scan results.

## Type of Change

- [ ] 📖 Documentation
- [ ] 🪲 Fix
- [x] 🩹 Patch
- [ ] ⚠️ Security Fix
- [ ] 🚀 Feature
- [ ] 💥 Breaking Change
