### PR TITLE
Pin checkout action to SHA of v4.2.2

### DIFF
--- a/.github/workflows/Label-PRs.yml
+++ b/.github/workflows/Label-PRs.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Apply labels
         uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
         with:


### PR DESCRIPTION
Updated checkout action version to v4.2.2.

<!-- markdownlint-configure-file { "MD012": false } -->
<!--- Provide a general summary of your changes in the Title above -->
# Pull Request

## Description
<!-- Please include a clear description of what your pull request does.
Remember to only include one change (or group of tightly related changes)
per pull request to make review and testing easier. -->

This pull request updates the GitHub Actions workflow to use a specific commit SHA for the `actions/checkout` step instead of a version tag. This change improves security and reliability by ensuring the workflow always uses the exact intended version of the action.

Workflow dependency pinning:

* [`.github/workflows/Label-PRs.yml`](diffhunk://#diff-3260d2161a7867040308ed963844c265fd96fabf1de04fc2684a7e9efac8245bL24-R24): Changed the `actions/checkout` step to use a commit SHA (`11bd71901bbe5b1630ceea73d27597364c9af683`) instead of the version tag `v4`, ensuring reproducible and secure builds.
