### PR TITLE
Add documentation and improve Dependabot workflow

### DIFF
--- a/.github/workflows/Dependabot-Auto-Approve.yml
+++ b/.github/workflows/Dependabot-Auto-Approve.yml
@@ -38,7 +38,7 @@ jobs:
         id: nuget_check
         run: |
           set -e
-          MATCHING_FILES=$(gh pr view "$PR_NUMBER" --json files --jq '
+          MATCHING_FILES=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json files --jq '
             .files[].path | select(
               . == "src/DLLPickle.Build/DLLPickle.csproj" or
               . == "src/DLLPickle.Build/packages.lock.json"


### PR DESCRIPTION
<!-- markdownlint-configure-file { "MD012": false } -->
<!--- Provide a general summary of your changes in the Title above -->
# Pull Request

## Description
<!-- Please include a clear description of what your pull request does.
Remember to only include one change (or group of tightly related changes)
per pull request to make review and testing easier. -->

This pull request updates the Dependabot auto-approve workflow to ensure the correct repository context is used when checking pull request files. The main change is to explicitly specify the repository in the `gh pr view` command, which improves reliability when running in different contexts.

Workflow reliability improvement:

* Updated the `gh pr view` command in `.github/workflows/Dependabot-Auto-Approve.yml` to include the `--repo "$GITHUB_REPOSITORY"` flag, ensuring that file checks are performed against the correct repository.

## Type of Change

- [ ] 📖 Documentation
- [ ] 🪲 Fix
- [ ] 🩹 Patch
- [ ] ⚠️ Security Fix
- [ ] 🚀 Feature
- [ ] 💥 Breaking Change

## Issue Resolved
<!-- If this PR resolves an issue, enter the issue number here. -->



## Automated Checks

The following checks run automatically and must pass before this PR can be merged:

- **Build Module** — matrix across Windows, Linux, and macOS; runs PSScriptAnalyzer (default rules + OTBS formatting + PS 5.1 compatibility), Pester unit tests (≥30% coverage), and full module build
- **Dependency Review** — blocks PRs introducing dependencies with known vulnerabilities (moderate severity or higher)
- **Validate .NET Packages** — NuGet lock file is enforced; resolved packages must match `packages.lock.json`

## Checklist

- [ ] I have reviewed my code for errors and tested it.
- [ ] My pull request does not contain multiple types of changes.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation as necessary.
- [ ] I have read the **CONTRIBUTING** document.

### Testing

If possible, we kindly ask that Pester tests be added for any new or changed functionality.

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
