### PR TITLE
ci: disable NuGet cache on the PR smoke-validation job

### DIFF
--- a/.github/workflows/Upstream-Compatibility.yml
+++ b/.github/workflows/Upstream-Compatibility.yml
@@ -41,8 +41,12 @@ jobs:
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: "8.0.x"
-          cache: true
-          cache-dependency-path: "src/DLLPickle.Build/packages.lock.json"
+          # This job runs only Analyze,Test (PowerShell) and performs no `dotnet restore`, so the
+          # NuGet global-packages folder is never created. Enabling the setup-dotnet cache makes its
+          # post-job save step fail ("Cache folder path ... doesn't exist on disk") on any cache miss
+          # (e.g. when packages.lock.json changes). The job needs no restored packages, so caching is
+          # disabled rather than worked around.
+          cache: false
 
       - name: Bootstrap
         shell: pwsh


### PR DESCRIPTION
## Summary

Fixes the intermittent **"Validate upstream compatibility tooling"** check failure seen on PRs that change `src/DLLPickle.Build/packages.lock.json` (e.g. #215).

### Root cause

The `pr-smoke-validation` job runs only:

```
Invoke-Build -File ./build/DLLPickle.Build.ps1 -Task Analyze,Test
```

`Analyze,Test` is PowerShell-only (PSScriptAnalyzer + Pester unit tests) — it performs **no `dotnet restore`**, so the NuGet global-packages folder (`~/.nuget/packages`) is never created. With `actions/setup-dotnet`'s `cache: true`, the **post-job cache-save** step then fails:

```
##[error]Cache folder path is retrieved for .NET CLI but doesn't exist on disk: C:\Users\runneradmin\.nuget\packages\
```

This marks the job failed even though Analyze and all unit tests passed. It only surfaces on a **cache miss** — i.e. when `packages.lock.json` changes — which is why it intermittently passed before (a prior cache hit pre-populated the folder).

### Fix

Set `cache: false` on the `pr-smoke-validation` job's `Setup .NET` step. The job needs no restored packages, so the NuGet cache provided no benefit — disabling it removes the failing post-step entirely rather than working around it.

The `scheduled-upstream-compatibility` job is intentionally **left as-is**: it runs `dotnet restore --locked-mode`, so `~/.nuget/packages` exists and its cache remains valid.

### Validation

- YAML parses cleanly.
- Only the smoke job changed; the scheduled job's `cache: true` + `cache-dependency-path` are untouched.
- The CI run on this PR exercises the fixed job directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
