### PR TITLE
feat(tools): preload-set analysis tooling (conflict matrix, drift comparer, ALC probe)

### DIFF
--- a/tests/Unit/ConflictMatrix.Tests.ps1
+++ b/tests/Unit/ConflictMatrix.Tests.ps1
@@ -43,4 +43,23 @@ Describe 'New-DLLPickleConflictMatrix' -Tag 'Unit' {
         $Matrix = & $ScriptPath -Inventory (New-TestInventory)
         @($Matrix.ConflictSurface) | Should -Be @('Azure.Core')
     }
+
+    It 'does not flag divergence when a single module ships one assembly at two versions' {
+        $Inventory = [PSCustomObject]@{
+            Modules = @(
+                [PSCustomObject]@{
+                    Name              = 'Az.Accounts'
+                    TrackedAssemblies = @(
+                        [PSCustomObject]@{ Name = 'Azure.Core'; Version = '1.50.0.0' }
+                        [PSCustomObject]@{ Name = 'Azure.Core'; Version = '1.46.0.0' }
+                    )
+                }
+            )
+        }
+        $Matrix = & $ScriptPath -Inventory $Inventory
+        $AzureCore = $Matrix.Assemblies | Where-Object Name -EQ 'Azure.Core'
+        $AzureCore.Diverges | Should -BeFalse
+        @($AzureCore.ShippedBy).Count | Should -Be 1
+        @($Matrix.ConflictSurface) | Should -BeNullOrEmpty
+    }
 }

--- a/tests/Unit/ConflictMatrix.Tests.ps1
+++ b/tests/Unit/ConflictMatrix.Tests.ps1
@@ -1,0 +1,46 @@
+BeforeAll {
+    $ScriptPath = Join-Path (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path 'tools\New-DLLPickleConflictMatrix.ps1'
+
+    function New-TestInventory {
+        # Two modules; Azure.Core diverges (1.50 vs 1.46), MSAL agrees (4.84.1).
+        [PSCustomObject]@{
+            Modules = @(
+                [PSCustomObject]@{
+                    Name              = 'Az.Accounts'
+                    TrackedAssemblies = @(
+                        [PSCustomObject]@{ Name = 'Azure.Core'; Version = '1.50.0.0' }
+                        [PSCustomObject]@{ Name = 'Microsoft.Identity.Client'; Version = '4.84.1.0' }
+                    )
+                }
+                [PSCustomObject]@{
+                    Name              = 'Microsoft.Graph.Authentication'
+                    TrackedAssemblies = @(
+                        [PSCustomObject]@{ Name = 'Azure.Core'; Version = '1.46.0.0' }
+                        [PSCustomObject]@{ Name = 'Microsoft.Identity.Client'; Version = '4.84.1.0' }
+                    )
+                }
+            )
+        }
+    }
+}
+
+Describe 'New-DLLPickleConflictMatrix' -Tag 'Unit' {
+    It 'flags an assembly shipped by >=2 modules at diverging versions' {
+        $Matrix = & $ScriptPath -Inventory (New-TestInventory)
+        $AzureCore = $Matrix.Assemblies | Where-Object Name -EQ 'Azure.Core'
+        $AzureCore.Diverges | Should -BeTrue
+        @($AzureCore.Versions).Count | Should -Be 2
+        @($AzureCore.ShippedBy) | Should -Contain 'Az.Accounts'
+    }
+
+    It 'does not flag an assembly all modules ship at the same version' {
+        $Matrix = & $ScriptPath -Inventory (New-TestInventory)
+        $Msal = $Matrix.Assemblies | Where-Object Name -EQ 'Microsoft.Identity.Client'
+        $Msal.Diverges | Should -BeFalse
+    }
+
+    It 'returns a ConflictSurface limited to diverging assemblies' {
+        $Matrix = & $ScriptPath -Inventory (New-TestInventory)
+        @($Matrix.ConflictSurface) | Should -Be @('Azure.Core')
+    }
+}

--- a/tests/Unit/ConflictMatrix.Tests.ps1
+++ b/tests/Unit/ConflictMatrix.Tests.ps1
@@ -1,7 +1,7 @@
 BeforeAll {
     $ScriptPath = Join-Path (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path 'tools\New-DLLPickleConflictMatrix.ps1'
 
-    function New-TestInventory {
+    function Get-TestInventory {
         # Two modules; Azure.Core diverges (1.50 vs 1.46), MSAL agrees (4.84.1).
         [PSCustomObject]@{
             Modules = @(
@@ -26,7 +26,7 @@ BeforeAll {
 
 Describe 'New-DLLPickleConflictMatrix' -Tag 'Unit' {
     It 'flags an assembly shipped by >=2 modules at diverging versions' {
-        $Matrix = & $ScriptPath -Inventory (New-TestInventory)
+        $Matrix = & $ScriptPath -Inventory (Get-TestInventory)
         $AzureCore = $Matrix.Assemblies | Where-Object Name -EQ 'Azure.Core'
         $AzureCore.Diverges | Should -BeTrue
         @($AzureCore.Versions).Count | Should -Be 2
@@ -34,13 +34,13 @@ Describe 'New-DLLPickleConflictMatrix' -Tag 'Unit' {
     }
 
     It 'does not flag an assembly all modules ship at the same version' {
-        $Matrix = & $ScriptPath -Inventory (New-TestInventory)
+        $Matrix = & $ScriptPath -Inventory (Get-TestInventory)
         $Msal = $Matrix.Assemblies | Where-Object Name -EQ 'Microsoft.Identity.Client'
         $Msal.Diverges | Should -BeFalse
     }
 
     It 'returns a ConflictSurface limited to diverging assemblies' {
-        $Matrix = & $ScriptPath -Inventory (New-TestInventory)
+        $Matrix = & $ScriptPath -Inventory (Get-TestInventory)
         @($Matrix.ConflictSurface) | Should -Be @('Azure.Core')
     }
 

--- a/tests/Unit/ConflictMatrixDrift.Tests.ps1
+++ b/tests/Unit/ConflictMatrixDrift.Tests.ps1
@@ -1,30 +1,30 @@
 BeforeAll {
     $ScriptPath = Join-Path (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path 'tools\Compare-DLLPickleConflictMatrix.ps1'
 
-    function New-Row { param($Name, $Diverges, $Alc = 'Default')
+    function Get-DriftRow { param($Name, $Diverges, $Alc = 'Default')
         [PSCustomObject]@{ Name = $Name; Diverges = $Diverges; AlcOwner = $Alc }
     }
-    function New-Mtx { param($Rows) [PSCustomObject]@{ Assemblies = @($Rows) } }
+    function Get-DriftMatrix { param($Rows) [PSCustomObject]@{ Assemblies = @($Rows) } }
 }
 
 Describe 'Compare-DLLPickleConflictMatrix' -Tag 'Unit' {
     It 'reports no material drift when the conflict surface is unchanged' {
-        $b = New-Mtx @( New-Row 'Azure.Core' $true )
-        $c = New-Mtx @( New-Row 'Azure.Core' $true )
+        $b = Get-DriftMatrix @( Get-DriftRow 'Azure.Core' $true )
+        $c = Get-DriftMatrix @( Get-DriftRow 'Azure.Core' $true )
         (& $ScriptPath -Baseline $b -Current $c).HasMaterialDrift | Should -BeFalse
     }
 
     It 'flags a newly diverging assembly' {
-        $b = New-Mtx @( New-Row 'Azure.Core' $true )
-        $c = New-Mtx @( (New-Row 'Azure.Core' $true), (New-Row 'Newtonsoft.Json' $true) )
+        $b = Get-DriftMatrix @( Get-DriftRow 'Azure.Core' $true )
+        $c = Get-DriftMatrix @( (Get-DriftRow 'Azure.Core' $true), (Get-DriftRow 'Newtonsoft.Json' $true) )
         $r = & $ScriptPath -Baseline $b -Current $c
         $r.HasMaterialDrift | Should -BeTrue
         $r.Findings.NewConflicts | Should -Contain 'Newtonsoft.Json'
     }
 
     It 'flags an ALC-ownership change' {
-        $b = New-Mtx @( New-Row 'Azure.Core' $true 'Default' )
-        $c = New-Mtx @( New-Row 'Azure.Core' $true 'AzSharedAssemblyLoadContext' )
+        $b = Get-DriftMatrix @( Get-DriftRow 'Azure.Core' $true 'Default' )
+        $c = Get-DriftMatrix @( Get-DriftRow 'Azure.Core' $true 'AzSharedAssemblyLoadContext' )
         $r = & $ScriptPath -Baseline $b -Current $c
         $r.HasMaterialDrift | Should -BeTrue
         $r.Findings.AlcOwnershipChanges | Should -Contain 'Azure.Core'

--- a/tests/Unit/ConflictMatrixDrift.Tests.ps1
+++ b/tests/Unit/ConflictMatrixDrift.Tests.ps1
@@ -1,0 +1,32 @@
+BeforeAll {
+    $ScriptPath = Join-Path (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path 'tools\Compare-DLLPickleConflictMatrix.ps1'
+
+    function New-Row { param($Name, $Diverges, $Alc = 'Default')
+        [PSCustomObject]@{ Name = $Name; Diverges = $Diverges; AlcOwner = $Alc }
+    }
+    function New-Mtx { param($Rows) [PSCustomObject]@{ Assemblies = @($Rows) } }
+}
+
+Describe 'Compare-DLLPickleConflictMatrix' -Tag 'Unit' {
+    It 'reports no material drift when the conflict surface is unchanged' {
+        $b = New-Mtx @( New-Row 'Azure.Core' $true )
+        $c = New-Mtx @( New-Row 'Azure.Core' $true )
+        (& $ScriptPath -Baseline $b -Current $c).HasMaterialDrift | Should -BeFalse
+    }
+
+    It 'flags a newly diverging assembly' {
+        $b = New-Mtx @( New-Row 'Azure.Core' $true )
+        $c = New-Mtx @( (New-Row 'Azure.Core' $true), (New-Row 'Newtonsoft.Json' $true) )
+        $r = & $ScriptPath -Baseline $b -Current $c
+        $r.HasMaterialDrift | Should -BeTrue
+        $r.Findings.NewConflicts | Should -Contain 'Newtonsoft.Json'
+    }
+
+    It 'flags an ALC-ownership change' {
+        $b = New-Mtx @( New-Row 'Azure.Core' $true 'Default' )
+        $c = New-Mtx @( New-Row 'Azure.Core' $true 'AzSharedAssemblyLoadContext' )
+        $r = & $ScriptPath -Baseline $b -Current $c
+        $r.HasMaterialDrift | Should -BeTrue
+        $r.Findings.AlcOwnershipChanges | Should -Contain 'Azure.Core'
+    }
+}

--- a/tools/Compare-DLLPickleConflictMatrix.ps1
+++ b/tools/Compare-DLLPickleConflictMatrix.ps1
@@ -1,0 +1,46 @@
+<#
+.SYNOPSIS
+    Diffs two DLLPickle conflict matrices and reports material drift.
+.DESCRIPTION
+    Material drift = a newly diverging assembly entering the conflict surface, or an ALC-ownership
+    change on a known assembly. Patch/minor moves with no new conflict and no ALC change are not
+    material. Returns an object with HasMaterialDrift and a Findings breakdown.
+.PARAMETER Baseline
+    The baseline conflict matrix (as produced by New-DLLPickleConflictMatrix.ps1).
+.PARAMETER Current
+    The current conflict matrix to compare against the baseline.
+.OUTPUTS
+    PSCustomObject { HasMaterialDrift [bool]; Findings { NewConflicts; RemovedConflicts; AlcOwnershipChanges } }
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [PSCustomObject]$Baseline,
+    [Parameter(Mandatory)] [PSCustomObject]$Current
+)
+
+$ErrorActionPreference = 'Stop'
+
+$BaseSurface = @($Baseline.Assemblies | Where-Object Diverges | ForEach-Object Name)
+$CurrSurface = @($Current.Assemblies  | Where-Object Diverges | ForEach-Object Name)
+
+$NewConflicts     = @($CurrSurface | Where-Object { $_ -notin $BaseSurface })
+$RemovedConflicts = @($BaseSurface | Where-Object { $_ -notin $CurrSurface })
+
+$BaseAlc = @{}
+foreach ($Assembly in $Baseline.Assemblies) {
+    $BaseAlc[$Assembly.Name] = [string]$Assembly.AlcOwner
+}
+$AlcChanges = @($Current.Assemblies | Where-Object {
+        $BaseAlc.ContainsKey($_.Name) -and $BaseAlc[$_.Name] -ne [string]$_.AlcOwner
+    } | ForEach-Object Name)
+
+$Findings = [PSCustomObject]@{
+    NewConflicts        = $NewConflicts
+    RemovedConflicts    = $RemovedConflicts
+    AlcOwnershipChanges = $AlcChanges
+}
+
+[PSCustomObject]@{
+    HasMaterialDrift = ($NewConflicts.Count -gt 0 -or $AlcChanges.Count -gt 0)
+    Findings         = $Findings
+}

--- a/tools/Get-DLLPickleRuntimeAssemblySnapshot.ps1
+++ b/tools/Get-DLLPickleRuntimeAssemblySnapshot.ps1
@@ -1,0 +1,70 @@
+<#
+.SYNOPSIS
+    Snapshots which identity-stack assemblies a module loads, and into which AssemblyLoadContext.
+.DESCRIPTION
+    Spawns a fresh pwsh process, optionally preloads DLLPickle, imports the named module(s) in
+    order, optionally runs a probe command, and returns each loaded Azure.*/Microsoft.Identity*/
+    Microsoft.IdentityModel*/System.ClientModel/System.Text.Json assembly with its version, path,
+    and ALC name. A private ALC (name other than 'Default') indicates the module self-manages that
+    assembly, which is a strong signal that DLLPickle must NOT preload it.
+.PARAMETER ModuleName
+    One or more modules to import, in order.
+.PARAMETER PreloadDllPickleManifest
+    Optional path to a DLLPickle manifest; when supplied, Import-DPLibrary runs before the imports.
+.PARAMETER ProbeCommand
+    Optional command string run after imports (e.g. 'Get-AzContext') to force lazy ALC init.
+.OUTPUTS
+    PSCustomObject[] one row per loaded assembly: Name, Version, Alc, Path.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string[]]$ModuleName,
+
+    [Parameter()]
+    [string]$PreloadDllPickleManifest,
+
+    [Parameter()]
+    [string]$ProbeCommand
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ChildScript = @'
+param($ModuleNames, $PreloadManifest, $ProbeCommand)
+$ModuleNames = $ModuleNames -split ','
+$ErrorActionPreference = 'Continue'
+if ($PreloadManifest) {
+    Import-Module $PreloadManifest -Force
+    Import-DPLibrary -SuppressLogo | Out-Null
+}
+foreach ($Name in $ModuleNames) { Import-Module $Name -Force -ErrorAction Continue }
+if ($ProbeCommand) { try { Invoke-Expression $ProbeCommand | Out-Null } catch { } }
+
+$Pattern = '^(Azure\.|Microsoft\.Identity|Microsoft\.IdentityModel|System\.ClientModel|System\.Text\.Json|System\.Memory\.Data|Microsoft\.Bcl\.AsyncInterfaces|Microsoft\.Extensions\.)'
+[System.AppDomain]::CurrentDomain.GetAssemblies() |
+    Where-Object { $_.GetName().Name -match $Pattern } |
+    ForEach-Object {
+        $Alc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext($_)
+        [PSCustomObject]@{
+            Name    = $_.GetName().Name
+            Version = $_.GetName().Version.ToString()
+            Alc     = if ($Alc -and $Alc.Name) { $Alc.Name } else { 'Default' }
+            Path    = $_.Location
+        }
+    } | ConvertTo-Json -Depth 5
+'@
+
+$TempScript = Join-Path ([System.IO.Path]::GetTempPath()) ("dpp-snap-{0}.ps1" -f ([System.Guid]::NewGuid().ToString('n')))
+Set-Content -LiteralPath $TempScript -Value $ChildScript -Encoding utf8NoBOM
+try {
+    $ChildArguments = @('-NoProfile', '-NonInteractive', '-File', $TempScript, '-ModuleNames', ($ModuleName -join ','))
+    if ($PreloadDllPickleManifest) { $ChildArguments += @('-PreloadManifest', $PreloadDllPickleManifest) }
+    if ($ProbeCommand) { $ChildArguments += @('-ProbeCommand', $ProbeCommand) }
+    $Raw = & pwsh @ChildArguments
+    $Json = ($Raw | Out-String).Trim()
+    if ([string]::IsNullOrWhiteSpace($Json)) { return @() }
+    @($Json | ConvertFrom-Json)
+} finally {
+    Remove-Item -LiteralPath $TempScript -Force -ErrorAction SilentlyContinue
+}

--- a/tools/New-DLLPickleConflictMatrix.ps1
+++ b/tools/New-DLLPickleConflictMatrix.ps1
@@ -1,0 +1,77 @@
+<#
+.SYNOPSIS
+    Builds a cross-module assembly conflict matrix from a DLLPickle upstream inventory.
+.DESCRIPTION
+    Consumes the inventory object produced by Get-DLLPickleUpstreamInventory.ps1 (or its JSON,
+    via -InventoryPath) and computes, per tracked assembly: which modules ship it, the distinct
+    versions, whether those versions diverge, and a placeholder AlcOwner field that the runtime
+    probe fills in later. The ConflictSurface is the set of assemblies that diverge across modules.
+.PARAMETER Inventory
+    The inventory object (as returned by Get-DLLPickleUpstreamInventory.ps1).
+.PARAMETER InventoryPath
+    Path to an inventory JSON file (alternative to -Inventory).
+.PARAMETER OutputPath
+    Optional path to write the matrix as JSON.
+.OUTPUTS
+    PSCustomObject the conflict matrix.
+#>
+[CmdletBinding(DefaultParameterSetName = 'Object')]
+param(
+    [Parameter(Mandatory, ParameterSetName = 'Object')]
+    [PSCustomObject]$Inventory,
+
+    [Parameter(Mandatory, ParameterSetName = 'Path')]
+    [ValidateNotNullOrEmpty()]
+    [string]$InventoryPath,
+
+    [Parameter()]
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($PSCmdlet.ParameterSetName -eq 'Path') {
+    $Inventory = Get-Content -LiteralPath $InventoryPath -Raw | ConvertFrom-Json
+}
+
+# Group every tracked assembly across all modules by assembly name.
+$ByAssembly = @{}
+foreach ($Module in $Inventory.Modules) {
+    foreach ($Assembly in $Module.TrackedAssemblies) {
+        if (-not $ByAssembly.ContainsKey($Assembly.Name)) {
+            $ByAssembly[$Assembly.Name] = [System.Collections.Generic.List[object]]::new()
+        }
+        $ByAssembly[$Assembly.Name].Add([PSCustomObject]@{
+                Module  = $Module.Name
+                Version = [string]$Assembly.Version
+            })
+    }
+}
+
+$AssemblyRows = foreach ($Name in ($ByAssembly.Keys | Sort-Object)) {
+    $Entries = $ByAssembly[$Name]
+    $DistinctVersions = @($Entries.Version | Sort-Object -Unique)
+    [PSCustomObject]@{
+        Name      = $Name
+        ShippedBy = @($Entries.Module | Sort-Object -Unique)
+        Versions  = $DistinctVersions
+        Diverges  = ($Entries.Module.Count -ge 2 -and $DistinctVersions.Count -ge 2)
+        AlcOwner  = $null   # filled by the runtime probe / adjudication
+    }
+}
+
+$Matrix = [PSCustomObject]@{
+    GeneratedAtUtc  = $null   # stamped by the caller; avoids non-deterministic test output
+    Assemblies      = @($AssemblyRows)
+    ConflictSurface = @($AssemblyRows | Where-Object Diverges | ForEach-Object Name)
+}
+
+if ($OutputPath) {
+    $OutputDirectory = Split-Path -Path $OutputPath -Parent
+    if ($OutputDirectory -and -not (Test-Path -LiteralPath $OutputDirectory -PathType Container)) {
+        $null = New-Item -Path $OutputDirectory -ItemType Directory -Force
+    }
+    $Matrix | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $OutputPath -Encoding utf8NoBOM
+}
+
+$Matrix

--- a/tools/New-DLLPickleConflictMatrix.ps1
+++ b/tools/New-DLLPickleConflictMatrix.ps1
@@ -51,11 +51,15 @@ foreach ($Module in $Inventory.Modules) {
 $AssemblyRows = foreach ($Name in ($ByAssembly.Keys | Sort-Object)) {
     $Entries = $ByAssembly[$Name]
     $DistinctVersions = @($Entries.Version | Sort-Object -Unique)
+    $DistinctModules = @($Entries.Module | Sort-Object -Unique)
     [PSCustomObject]@{
         Name      = $Name
-        ShippedBy = @($Entries.Module | Sort-Object -Unique)
+        ShippedBy = $DistinctModules
         Versions  = $DistinctVersions
-        Diverges  = ($Entries.Module.Count -ge 2 -and $DistinctVersions.Count -ge 2)
+        # Diverges only when >=2 DISTINCT modules ship >=2 distinct versions. Counting distinct
+        # modules (not raw entries) avoids a false positive when one module ships the same
+        # assembly more than once (e.g. nested folders / multiple RIDs) at differing versions.
+        Diverges  = ($DistinctModules.Count -ge 2 -and $DistinctVersions.Count -ge 2)
         AlcOwner  = $null   # filled by the runtime probe / adjudication
     }
 }


### PR DESCRIPTION
## Summary

Phase A/B **analysis tooling** from the [preload-set needs-analysis plan](docs/superpowers/plans/2026-05-31-dll-needs-analysis.md). Purely additive — three new `tools/` scripts + unit tests. **No build or runtime-behavior change** (the policy/csproj realization that closes #193 comes in a follow-up PR, since it needs runtime adjudication evidence).

- `tools/New-DLLPickleConflictMatrix.ps1` — inventory → cross-module conflict matrix (which modules ship each assembly, versions, divergence, ALC-owner placeholder). Unit-tested.
- `tools/Compare-DLLPickleConflictMatrix.ps1` — Stage 2 drift comparer (new conflicts / ALC-ownership changes → material drift). Unit-tested.
- `tools/Get-DLLPickleRuntimeAssemblySnapshot.ps1` — runtime ALC-ownership probe (spawns a fresh pwsh, imports modules, reports each identity-stack assembly's ALC). Smoke-validated against real Az.Accounts (Azure SDK assemblies confirmed in `AzSharedAssemblyLoadContext`).

### Review notes (caught during subagent-driven review)
- `Diverges` now counts **distinct modules**, not raw entries (a single module shipping one assembly at two versions is no longer a false conflict); regression test added.
- Fixture helpers renamed off state-changing verbs (`New-*` → `Get-*`) so `tests/` stays clean under the `AnalyzeTests` gate.

### Validation
`Invoke-Build -Task Analyze,Test` → 4 tasks, 0 errors (1 benign pre-existing `InvalidLibrary.dll` warning). New tests 7/7; full unit suite green; analyzer clean on `tools/` and `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
