### PR TITLE
fix(deps): stop preloading Microsoft.Extensions.* BCL transitives (closes #193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Working on updates to replace PlatyPS documentation creation with the new Microsoft.PowerShell.PlatyPS module. (PRs and other help would be welcomed!)
 
+## [2.0.2] - 2026-05-31
+
+### Fixed
+
+- `Import-Module Az.Resources` (and other Az.* modules) failing with `Could not load file or assembly 'Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0 ...'. Assembly with same name is already loaded` after `Import-DPLibrary` (#193). DLLPickle was preloading the `Microsoft.Extensions.DependencyInjection.Abstractions` and `Microsoft.Extensions.Logging.Abstractions` BCL transitives (pulled by `Microsoft.IdentityModel.Tokens`) into the default load context, where they collided with the copies Az modules bundle. `Microsoft.IdentityModel.Tokens` still loads correctly without them preloaded.
+
+### Removed
+
+- `Microsoft.Extensions.DependencyInjection.Abstractions` and `Microsoft.Extensions.Logging.Abstractions` from the bundled preload set (via `ExcludeAssets="runtime"`). They are incidental transitives, not part of DLLPickle's identity-coordination purpose, and PowerShell does not host-provide them — so preloading DLLPickle's own copies only caused conflicts with consuming modules. The service modules that need them supply them at runtime.
+
 ## [2.0.1] - 2026-05-31
 
 ### Fixed
@@ -249,7 +259,8 @@ Full Changelog: [v0.2.5...v0.2.6](https://github.com/SamErde/DLLPickle/compare/v
 
 - Initial release.
 
-[Unreleased]: https://github.com/SamErde/DLLPickle/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/SamErde/DLLPickle/compare/v2.0.2...HEAD
+[2.0.2]: https://github.com/SamErde/DLLPickle/tag/v2.0.2
 [2.0.1]: https://github.com/SamErde/DLLPickle/tag/v2.0.1
 [2.0.0]: https://github.com/SamErde/DLLPickle/tag/v2.0.0
 [1.3.1]: https://github.com/SamErde/DLLPickle/tag/v1.3.1

--- a/src/DLLPickle.Build/DLLPickle.csproj
+++ b/src/DLLPickle.Build/DLLPickle.csproj
@@ -28,6 +28,17 @@
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.*" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.*" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.*" />
+
+    <!-- #193: Do NOT preload the Microsoft.Extensions.* BCL transitives pulled by
+         Microsoft.IdentityModel.Tokens. They are not part of DLLPickle's identity-coordination
+         purpose, PowerShell does not host-provide them (it ships only Microsoft.Extensions.ObjectPool),
+         and preloading our own copies into the default ALC collides with modules that bundle their
+         own (e.g. Az.Resources 9.x -> "assembly with same name is already loaded"). ExcludeAssets="runtime"
+         keeps them out of the bundled bin so they are not preloaded; the consuming service modules
+         supply them. Logging.Abstractions depends on DependencyInjection.Abstractions, so both are
+         excluded together. -->
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.*" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.*" ExcludeAssets="runtime" />
   </ItemGroup>
 
 </Project>

--- a/src/DLLPickle.Build/packages.lock.json
+++ b/src/DLLPickle.Build/packages.lock.json
@@ -2,6 +2,21 @@
   "version": 1,
   "dependencies": {
     "net8.0": {
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Direct",
+        "requested": "[8.*, )",
+        "resolved": "8.0.2",
+        "contentHash": "3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Direct",
+        "requested": "[8.*, )",
+        "resolved": "8.0.3",
+        "contentHash": "dL0QGToTxggRLMYY4ZYX5AMwBb+byQBd/5dMiZE07Nv73o6I5Are3C7eQTh7K2+A4ct0PVISSr7TZANbiNb2yQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+        }
+      },
       "Microsoft.Identity.Client": {
         "type": "Direct",
         "requested": "[4.84.1, 4.84.1]",
@@ -80,19 +95,6 @@
         "dependencies": {
           "Microsoft.IdentityModel.JsonWebTokens": "8.18.0",
           "Microsoft.IdentityModel.Tokens": "8.18.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection.Abstractions": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "cjWrLkJXK0rs4zofsK4bSdg+jhDLTaxrkXu4gS6Y7MAlCvRyNNgwY/lJi5RDlQOnSZweHqoyvgvbdvQsRIW+hg=="
-      },
-      "Microsoft.Extensions.Logging.Abstractions": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "arDBqTgFCyS0EvRV7O3MZturChstm50OJ0y9bDJvAcmEPJm0FFpFyjU/JLYyStNGGey081DvnQYlncNX5SJJGA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0"
         }
       },
       "System.Diagnostics.DiagnosticSource": {

--- a/tests/Integration/DLLPickle.IntegrationTest.Tests.ps1
+++ b/tests/Integration/DLLPickle.IntegrationTest.Tests.ps1
@@ -36,4 +36,27 @@ Describe 'Built module integration validation' -Tag 'Integration' {
         @($ImportResults | Where-Object AssemblyName -EQ 'Azure.Core') | Should -BeNullOrEmpty
         @($ImportResults | Where-Object DLLName -EQ 'Azure.Core.dll') | Should -BeNullOrEmpty
     }
+
+    It 'does not preload the Microsoft.Extensions.* BCL transitives (regression guard for #193 / Az.Resources)' {
+        # These are incidental transitives of Microsoft.IdentityModel.Tokens, not part of DLLPickle's
+        # identity-coordination purpose. PowerShell does not host-provide them, and preloading our own
+        # copies into the default ALC collides with modules that bundle their own (Az.Resources 9.x ->
+        # "Microsoft.Extensions.DependencyInjection.Abstractions ... assembly with same name is already
+        # loaded"). They are excluded from the bundle via ExcludeAssets in DLLPickle.csproj.
+        $BinPath = Join-Path (Split-Path -Path $BuiltModuleManifestPath -Parent) 'bin\net8.0'
+
+        # Packaging invariant: the Extensions BCL transitives must not be shipped.
+        Join-Path $BinPath 'Microsoft.Extensions.DependencyInjection.Abstractions.dll' | Should -Not -Exist
+        Join-Path $BinPath 'Microsoft.Extensions.Logging.Abstractions.dll' | Should -Not -Exist
+
+        Remove-Module DLLPickle -Force -ErrorAction SilentlyContinue
+        Import-Module $BuiltModuleManifestPath -Force
+
+        # Behavioral invariant: Import-DPLibrary must not report them among preloaded assemblies,
+        # and Microsoft.IdentityModel.Tokens must still load successfully without them bundled.
+        $ImportResults = @(Import-DPLibrary -SuppressLogo)
+        @($ImportResults | Where-Object DLLName -Like 'Microsoft.Extensions.*') | Should -BeNullOrEmpty
+        $Tokens = $ImportResults | Where-Object DLLName -EQ 'Microsoft.IdentityModel.Tokens.dll'
+        $Tokens.Status | Should -Not -Be 'Failed'
+    }
 }


### PR DESCRIPTION
## Summary

Fixes **#193** — `Import-Module Az.Resources` (and other Az.* modules) failing after `Import-DPLibrary` with:

```
Could not load file or assembly 'Microsoft.Extensions.DependencyInjection.Abstractions,
Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'. Assembly with same name is already loaded
```

**Confirmed reproducing on the published 2.0.1.**

### Root cause (runtime-measured)
DLLPickle preloads `Microsoft.Extensions.DependencyInjection.Abstractions` and `Microsoft.Extensions.Logging.Abstractions` — *incidental transitives* of `Microsoft.IdentityModel.Tokens` — into the **default** AssemblyLoadContext. PowerShell 7.6 does **not** host-provide them (it ships only `Microsoft.Extensions.ObjectPool`), and Az.Resources 9.x bundles its own copies. DLLPickle's preloaded copy occupies the default-ALC slot, so Az.Resources' import collides. These assemblies are **not** part of DLLPickle's identity-coordination purpose.

### Fix
Exclude both from the bundle via `ExcludeAssets="runtime"` in `DLLPickle.csproj` (they're a pair — `Logging.Abstractions` depends on `DependencyInjection.Abstractions`). The consuming service modules supply them at runtime.

### Validation done locally
- Build output + `module/bin/net8.0` no longer contain either DLL.
- `Import-DPLibrary` loads with **0 failures**, and **`Microsoft.IdentityModel.Tokens` still imports cleanly** without the transitives bundled (its dependency resolves lazily).
- Integration suite 9/9 (incl. a new regression guard); `Analyze,Test` 0 errors; analyzer clean; coverage 63.78%.

### ⚠️ Validation still needed before merge (maintainer / your environment)
This **changes the bundle**, so please run, against this branch's built module:

```powershell
# build this branch, then in a fresh PS 7 session importing THIS module/ build:
Import-DPLibrary
Import-Module Az.Resources      # should now succeed (was the #193 failure)
# and confirm no regression to the base profile:
Import-DPBaseProfile
Connect-ExchangeOnline; Connect-MicrosoftTeams; Connect-MgGraph; Connect-AzAccount -Tenant $MyTenantId
```

Ships as **2.0.2** via the tag-driven flow (CHANGELOG entry included). Not auto-merged — awaiting your sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
