### PR TITLE
feat: 2.1.0 — Dependabot-managed floating deps, recorded preload policy, drift gate

### DIFF
--- a/.github/workflows/Release-and-Publish.yml
+++ b/.github/workflows/Release-and-Publish.yml
@@ -7,6 +7,8 @@ on:
       - main
     paths:
       - "src/DLLPickle/**"
+      - "src/DLLPickle.Build/**"
+      - "build/**"
       - "module/**"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/Upstream-Compatibility.yml
+++ b/.github/workflows/Upstream-Compatibility.yml
@@ -94,6 +94,45 @@ jobs:
             -OutputPath ./artifacts/upstreamCompatibility/upstream-inventory.json `
             -Force
 
+      - name: Detect conflict-surface drift
+        id: drift
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          ./tools/New-DLLPickleConflictMatrix.ps1 `
+            -InventoryPath ./artifacts/upstreamCompatibility/upstream-inventory.json `
+            -OutputPath ./artifacts/upstreamCompatibility/conflict-matrix.json | Out-Null
+          $policy = Get-Content ./build/dependency-policy.json -Raw | ConvertFrom-Json
+          $current = Get-Content ./artifacts/upstreamCompatibility/conflict-matrix.json -Raw | ConvertFrom-Json
+          $surface = @($current.ConflictSurface | Sort-Object)
+          $bytes = [System.Text.Encoding]::UTF8.GetBytes(($surface -join '|'))
+          $fingerprint = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::HashData($bytes)).Replace('-', '').ToLowerInvariant()
+          $baseline = [string]$policy.baseline.conflictSurfaceFingerprint
+          if ($fingerprint -ne $baseline) {
+            Write-Host "::warning::Conflict surface changed (baseline '$baseline' -> '$fingerprint'). The preload decision in build/dependency-policy.json needs human review."
+            "drift=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            $Title = 'Conflict-surface drift detected'
+            $Body = @(
+              'The DLLPickle conflict surface changed versus the recorded baseline.'
+              ''
+              "Baseline fingerprint: ``$baseline``"
+              "Current fingerprint: ``$fingerprint``"
+              ''
+              'Current conflict surface:'
+              ($surface | ForEach-Object { "- $_" })
+              ''
+              'Re-run the runtime ALC adjudication and update build/dependency-policy.json (classification + evidence + baseline) per docs/Architecture.md section 8.'
+            ) -join [System.Environment]::NewLine
+            $Existing = gh issue list --state open --search "$Title in:title" --json number --jq '.[0].number'
+            if ([string]::IsNullOrWhiteSpace($Existing)) { gh issue create --title $Title --body $Body }
+            else { gh issue comment $Existing --body $Body }
+          } else {
+            Write-Host "Conflict surface unchanged (fingerprint '$fingerprint')."
+            "drift=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          }
+
       - name: Generate candidate dependency updates
         shell: pwsh
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Working on updates to replace PlatyPS documentation creation with the new Microsoft.PowerShell.PlatyPS module. (PRs and other help would be welcomed!)
 
+## [2.1.0] - 2026-05-31
+
+> The bundled assembly versions are **unchanged** from 2.0.2 (the floating ranges resolve to the same MSAL 4.84.1 / NativeInterop 0.20.6 — the current latest within their majors). This release is about **how dependencies are managed and validated going forward**, not a runtime change.
+
+### Changed
+
+- The MSAL/broker dependency pins are now **major-locked floating** (`Microsoft.Identity.Client` and friends `[4.84.1]` → `4.*`, `NativeInterop` `[0.20.6]` → `0.*`), so Dependabot manages minor/patch updates within the major (gated by the upstream-compatibility checks); major bumps remain a manual, reviewed edit.
+
+### Added
+
+- A **conflict-surface drift gate** in the Upstream-Compatibility workflow: it builds the cross-module conflict matrix, compares its fingerprint to a recorded baseline in `build/dependency-policy.json`, and opens an issue when the surface changes so the preload decision is re-adjudicated.
+- New analysis tooling under `tools/` — `New-DLLPickleConflictMatrix`, `Compare-DLLPickleConflictMatrix`, and `Get-DLLPickleRuntimeAssemblySnapshot` (runtime AssemblyLoadContext probe) — plus unit tests.
+- `docs/Architecture.md` — a durable, agent-oriented architecture blueprint (runtime/ALC model, preload/block taxonomy, invariants and their enforcing gates, source-of-truth map, and a Windows PowerShell 5.1 / net48 re-introduction checklist).
+
+### Fixed
+
+- The Release-and-Publish workflow now also triggers on `src/DLLPickle.Build/**` and `build/**` changes; previously a dependency-only change (like the 2.0.2 fix) would not auto-trigger a release on merge.
+
+### Internal
+
+- `build/dependency-policy.json` records the full, evidence-backed preload/block classification for every tracked assembly (Azure SDK stack and the `Microsoft.Extensions.*` transitives are `block`; the MSAL + IdentityModel stack is `preload`), the four-module target scenario, and the drift baseline. Documents the runtime finding that both Az.Accounts and Microsoft.Graph.Authentication now self-isolate their Azure SDK stack in private ALCs.
+
 ## [2.0.2] - 2026-05-31
 
 ### Fixed
@@ -259,7 +281,8 @@ Full Changelog: [v0.2.5...v0.2.6](https://github.com/SamErde/DLLPickle/compare/v
 
 - Initial release.
 
-[Unreleased]: https://github.com/SamErde/DLLPickle/compare/v2.0.2...HEAD
+[Unreleased]: https://github.com/SamErde/DLLPickle/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/SamErde/DLLPickle/tag/v2.1.0
 [2.0.2]: https://github.com/SamErde/DLLPickle/tag/v2.0.2
 [2.0.1]: https://github.com/SamErde/DLLPickle/tag/v2.0.1
 [2.0.0]: https://github.com/SamErde/DLLPickle/tag/v2.0.0

--- a/build/dependency-policy.json
+++ b/build/dependency-policy.json
@@ -69,8 +69,14 @@
     ]
   },
   "baseline": {
-    "moduleVersions": {},
-    "conflictSurfaceFingerprint": null
+    "capturedOn": "2026-05-31",
+    "moduleVersions": {
+      "Az.Accounts": "5.4.0",
+      "Microsoft.Graph.Authentication": "2.37.0",
+      "ExchangeOnlineManagement": "3.9.2",
+      "MicrosoftTeams": "7.8.0"
+    },
+    "conflictSurfaceFingerprint": "6a0ea4e7b401c8d3debb081b534d63bb7edf7c5ee61eea21a50ab126feae13ca"
   },
   "preload": [
     {
@@ -86,7 +92,12 @@
         "ExchangeOnlineManagement"
       ],
       "updateMode": "candidatePullRequest",
-      "reason": "The base profile uses the highest Microsoft.Identity.Client assembly from Az, Graph, Teams, and Exchange so shared MSAL method contracts remain consistent."
+      "reason": "The base profile uses the highest Microsoft.Identity.Client assembly from Az, Graph, Teams, and Exchange so shared MSAL method contracts remain consistent.",
+      "evidence": {
+        "alcOwner": "Default",
+        "basis": "In the cross-module conflict surface; default-ALC-shared. Preloading the MSAL line is validated by the 2.0.1/2.0.2 four-module connect and underpins the #156 broker fix.",
+        "decidedOn": "2026-05-31"
+      }
     },
     {
       "packageName": "Microsoft.Identity.Client.Broker",
@@ -101,7 +112,12 @@
         "ExchangeOnlineManagement"
       ],
       "updateMode": "candidatePullRequest",
-      "reason": "The base profile requires the broker extension assembly to stay aligned with the selected MSAL line."
+      "reason": "The base profile requires the broker extension assembly to stay aligned with the selected MSAL line.",
+      "evidence": {
+        "alcOwner": "Default",
+        "basis": "Default-ALC-shared; the #156 reproduction is a WithBroker missing-method failure when the broker line is misaligned. Validated by the 2.0.1/2.0.2 four-module connect.",
+        "decidedOn": "2026-05-31"
+      }
     },
     {
       "packageName": "Microsoft.Identity.Client.Extensions.Msal",
@@ -115,20 +131,230 @@
         "MicrosoftTeams"
       ],
       "updateMode": "candidatePullRequest",
-      "reason": "Az.Accounts and Microsoft.Graph.Authentication both use the MSAL cache helper; preloading the highest compatible cache helper prevents missing-method failures after mixed imports."
+      "reason": "Az.Accounts and Microsoft.Graph.Authentication both use the MSAL cache helper; preloading the highest compatible cache helper prevents missing-method failures after mixed imports.",
+      "evidence": {
+        "alcOwner": "Default",
+        "basis": "Block CANDIDATE by ALC ownership (observed in Az's AzSharedAssemblyLoadContext), but runtime decides PRELOAD: preloading the MSAL/cache-helper line is proven safe by the 2.0.1/2.0.2 four-module connect. Only the Azure SDK stack breaks when preloaded.",
+        "decidedOn": "2026-05-31"
+      }
+    },
+    {
+      "packageName": "Microsoft.Identity.Client.NativeInterop",
+      "assemblyName": "Microsoft.Identity.Client.NativeInterop",
+      "targetFramework": "net8.0",
+      "classification": "preload",
+      "versionPolicy": "minorPatchFloat",
+      "sourceModules": [
+        "Az.Accounts",
+        "MicrosoftTeams"
+      ],
+      "updateMode": "candidatePullRequest",
+      "reason": "Broker native-interop dependency; bundled so the broker's native runtime files (added to PATH by Import-DPLibrary) are available. Floats with the MSAL/broker line.",
+      "evidence": {
+        "alcOwner": "Default",
+        "basis": "Ships native runtime DLLs that Import-DPLibrary surfaces on PATH. Tracks the broker requirement; validated by the 2.0.1/2.0.2 four-module connect.",
+        "decidedOn": "2026-05-31"
+      }
+    },
+    {
+      "packageName": "Microsoft.IdentityModel.Abstractions",
+      "assemblyName": "Microsoft.IdentityModel.Abstractions",
+      "targetFramework": "net8.0",
+      "classification": "preload",
+      "versionPolicy": "minorPatchFloat",
+      "sourceModules": [
+        "Az.Accounts",
+        "Microsoft.Graph.Authentication",
+        "MicrosoftTeams",
+        "ExchangeOnlineManagement"
+      ],
+      "updateMode": "candidatePullRequest",
+      "reason": "Shared IdentityModel token stack; preload a coherent 8.x line so mixed imports agree.",
+      "evidence": {
+        "alcOwner": "Default",
+        "basis": "Default-ALC-shared token-handling stack in the conflict surface; preloading a coherent 8.x line keeps mixed imports consistent (validated 2.0.1/2.0.2).",
+        "decidedOn": "2026-05-31"
+      }
+    },
+    {
+      "packageName": "Microsoft.IdentityModel.JsonWebTokens",
+      "assemblyName": "Microsoft.IdentityModel.JsonWebTokens",
+      "targetFramework": "net8.0",
+      "classification": "preload",
+      "versionPolicy": "minorPatchFloat",
+      "sourceModules": [
+        "Az.Accounts",
+        "Microsoft.Graph.Authentication",
+        "MicrosoftTeams",
+        "ExchangeOnlineManagement"
+      ],
+      "updateMode": "candidatePullRequest",
+      "reason": "Shared IdentityModel token stack; preload a coherent 8.x line so mixed imports agree.",
+      "evidence": {
+        "alcOwner": "Default",
+        "basis": "Default-ALC-shared token-handling stack in the conflict surface; coherent 8.x preload validated 2.0.1/2.0.2.",
+        "decidedOn": "2026-05-31"
+      }
+    },
+    {
+      "packageName": "Microsoft.IdentityModel.Logging",
+      "assemblyName": "Microsoft.IdentityModel.Logging",
+      "targetFramework": "net8.0",
+      "classification": "preload",
+      "versionPolicy": "minorPatchFloat",
+      "sourceModules": [
+        "Az.Accounts",
+        "Microsoft.Graph.Authentication",
+        "MicrosoftTeams",
+        "ExchangeOnlineManagement"
+      ],
+      "updateMode": "candidatePullRequest",
+      "reason": "Shared IdentityModel token stack; preload a coherent 8.x line so mixed imports agree.",
+      "evidence": {
+        "alcOwner": "Default",
+        "basis": "Default-ALC-shared token-handling stack in the conflict surface; coherent 8.x preload validated 2.0.1/2.0.2.",
+        "decidedOn": "2026-05-31"
+      }
+    },
+    {
+      "packageName": "Microsoft.IdentityModel.Tokens",
+      "assemblyName": "Microsoft.IdentityModel.Tokens",
+      "targetFramework": "net8.0",
+      "classification": "preload",
+      "versionPolicy": "minorPatchFloat",
+      "sourceModules": [
+        "Az.Accounts",
+        "Microsoft.Graph.Authentication",
+        "MicrosoftTeams",
+        "ExchangeOnlineManagement"
+      ],
+      "updateMode": "candidatePullRequest",
+      "reason": "Shared IdentityModel token stack; preload a coherent 8.x line so mixed imports agree.",
+      "evidence": {
+        "alcOwner": "Default",
+        "basis": "Default-ALC-shared token-handling stack in the conflict surface; coherent 8.x preload validated 2.0.1/2.0.2. Its incidental Microsoft.Extensions.* transitives are excluded from the bundle (see blockedPreloadAssemblies / #193).",
+        "decidedOn": "2026-05-31"
+      }
+    },
+    {
+      "packageName": "System.IdentityModel.Tokens.Jwt",
+      "assemblyName": "System.IdentityModel.Tokens.Jwt",
+      "targetFramework": "net8.0",
+      "classification": "preload",
+      "versionPolicy": "minorPatchFloat",
+      "sourceModules": [
+        "Az.Accounts",
+        "Microsoft.Graph.Authentication",
+        "MicrosoftTeams",
+        "ExchangeOnlineManagement"
+      ],
+      "updateMode": "candidatePullRequest",
+      "reason": "Shared JWT handler aligned with the IdentityModel 8.x line.",
+      "evidence": {
+        "alcOwner": "Default",
+        "basis": "Default-ALC-shared; aligned with the IdentityModel 8.x preload. Validated 2.0.1/2.0.2.",
+        "decidedOn": "2026-05-31"
+      }
     }
   ],
   "blockedPreloadAssemblies": [
     {
       "packageName": "Azure.Core",
       "assemblyName": "Azure.Core",
+      "classification": "block",
       "sourceModules": [
         "Az.Accounts",
         "Microsoft.Graph.Authentication",
         "MicrosoftTeams"
       ],
       "updateMode": "reportOnly",
-      "reason": "Azure.Core is intentionally not preloaded on the PowerShell 7.4+ (net8.0) profile. Az.Accounts 5.x isolates its Azure SDK stack in a private AssemblyLoadContext; preloading Azure.Core into the default load context splits Azure.Core.TokenRequestContext across load contexts and breaks Connect-AzAccount with a MissingMethodException on InteractiveBrowserCredential.AuthenticateAsync. Graph, Exchange, and Teams resolve a compatible Azure.Core themselves on .NET 8, so the preload is unnecessary for them. The original net48-only Azure.Core preload (#183) does not apply to the net8.0 baseline."
+      "reason": "Azure.Core is intentionally not preloaded on the PowerShell 7.4+ (net8.0) profile. Az.Accounts 5.x isolates its Azure SDK stack in a private AssemblyLoadContext; preloading Azure.Core into the default load context splits Azure.Core.TokenRequestContext across load contexts and breaks Connect-AzAccount with a MissingMethodException on InteractiveBrowserCredential.AuthenticateAsync. Graph, Exchange, and Teams resolve a compatible Azure.Core themselves on .NET 8, so the preload is unnecessary for them. The original net48-only Azure.Core preload (#183) does not apply to the net8.0 baseline.",
+      "evidence": {
+        "alcOwner": "AzSharedAssemblyLoadContext / msgraph-load-context",
+        "basis": "Runtime probe 2026-05-31: Az.Accounts and Microsoft.Graph.Authentication both self-isolate Azure.Core in private ALCs and run different versions side-by-side (1.50 vs 1.51.1). Preloading into the default ALC splits TokenRequestContext -> Connect-AzAccount MissingMethodException. Removed from the bundle in 2.0.1.",
+        "decidedOn": "2026-05-31"
+      }
+    },
+    {
+      "packageName": "Azure.Identity",
+      "assemblyName": "Azure.Identity",
+      "classification": "block",
+      "sourceModules": [
+        "Az.Accounts"
+      ],
+      "updateMode": "reportOnly",
+      "reason": "Azure SDK stack self-isolated by Az.Accounts (and Graph); not preloaded on the net8.0 profile.",
+      "evidence": {
+        "alcOwner": "AzSharedAssemblyLoadContext",
+        "basis": "Runtime probe 2026-05-31: loaded into Az's private ALC (1.13.0). Belongs to the Azure SDK stack that breaks when preloaded (Azure.Core class). Not bundled by DLLPickle.",
+        "decidedOn": "2026-05-31"
+      }
+    },
+    {
+      "packageName": "Azure.Identity.Broker",
+      "assemblyName": "Azure.Identity.Broker",
+      "classification": "block",
+      "sourceModules": [
+        "Az.Accounts"
+      ],
+      "updateMode": "reportOnly",
+      "reason": "Azure SDK broker stack self-managed by Az; not preloaded on the net8.0 profile.",
+      "evidence": {
+        "alcOwner": "AzSharedAssemblyLoadContext",
+        "basis": "In the conflict surface; part of the Az-self-isolated Azure SDK stack. Not bundled by DLLPickle.",
+        "decidedOn": "2026-05-31"
+      }
+    },
+    {
+      "packageName": "System.ClientModel",
+      "assemblyName": "System.ClientModel",
+      "classification": "block",
+      "sourceModules": [
+        "Microsoft.Graph.Authentication"
+      ],
+      "updateMode": "reportOnly",
+      "reason": "Azure SDK transitive (Azure.Core dependency) self-managed by Graph/Az; not preloaded on the net8.0 profile.",
+      "evidence": {
+        "alcOwner": "msgraph-load-context",
+        "basis": "Runtime probe 2026-05-31: loaded into Graph's private ALC (1.9.0) alongside Azure.Core. Transitive of the blocked Azure.Core. Not bundled by DLLPickle.",
+        "decidedOn": "2026-05-31"
+      }
+    },
+    {
+      "packageName": "Microsoft.Extensions.DependencyInjection.Abstractions",
+      "assemblyName": "Microsoft.Extensions.DependencyInjection.Abstractions",
+      "classification": "block",
+      "sourceModules": [
+        "Az.Accounts",
+        "Az.Resources",
+        "Microsoft.Graph.Authentication"
+      ],
+      "updateMode": "reportOnly",
+      "reason": "#193: incidental transitive of Microsoft.IdentityModel.Tokens, not part of DLLPickle's identity-coordination purpose and not host-provided. Excluded from the bundle (ExcludeAssets=runtime) so it does not collide with modules that bundle their own copy (Az.Resources).",
+      "evidence": {
+        "alcOwner": "Default (collision)",
+        "basis": "Diagnostic 2026-05-31: DLLPickle preloaded 8.0.0 into the default ALC; PowerShell ships only Microsoft.Extensions.ObjectPool (not this); Az.Resources 9.x bundles its own copy -> 'assembly with same name is already loaded' on Import-Module Az.Resources. Fixed in 2.0.2.",
+        "decidedOn": "2026-05-31",
+        "issue": "193"
+      }
+    },
+    {
+      "packageName": "Microsoft.Extensions.Logging.Abstractions",
+      "assemblyName": "Microsoft.Extensions.Logging.Abstractions",
+      "classification": "block",
+      "sourceModules": [
+        "Az.Accounts",
+        "Az.Resources",
+        "Microsoft.Graph.Authentication"
+      ],
+      "updateMode": "reportOnly",
+      "reason": "#193: paired with DependencyInjection.Abstractions (depends on it); same incidental-transitive collision with Az modules. Excluded from the bundle (ExcludeAssets=runtime).",
+      "evidence": {
+        "alcOwner": "Default (collision)",
+        "basis": "Excluded alongside DependencyInjection.Abstractions in 2.0.2. Microsoft.IdentityModel.Tokens still loads without it bundled (resolves lazily / supplied by the consuming service modules).",
+        "decidedOn": "2026-05-31",
+        "issue": "193"
+      }
     },
     {
       "packageName": "Microsoft.OData.Core",

--- a/build/dependency-policy.json
+++ b/build/dependency-policy.json
@@ -46,12 +46,39 @@
     "Microsoft.OData.Edm",
     "Microsoft.Spatial"
   ],
-  "exactPins": [
+  "targetScenario": {
+    "modules": [
+      "Az.Accounts",
+      "Microsoft.Graph.Authentication",
+      "ExchangeOnlineManagement",
+      "MicrosoftTeams"
+    ],
+    "importOrders": [
+      [
+        "ExchangeOnlineManagement",
+        "MicrosoftTeams",
+        "Microsoft.Graph.Authentication",
+        "Az.Accounts"
+      ],
+      [
+        "Az.Accounts",
+        "Microsoft.Graph.Authentication",
+        "ExchangeOnlineManagement",
+        "MicrosoftTeams"
+      ]
+    ]
+  },
+  "baseline": {
+    "moduleVersions": {},
+    "conflictSurfaceFingerprint": null
+  },
+  "preload": [
     {
       "packageName": "Microsoft.Identity.Client",
       "assemblyName": "Microsoft.Identity.Client",
       "targetFramework": "net8.0",
-      "versionSyntax": "exact",
+      "classification": "preload",
+      "versionPolicy": "minorPatchFloat",
       "sourceModules": [
         "Az.Accounts",
         "Microsoft.Graph.Authentication",
@@ -65,7 +92,8 @@
       "packageName": "Microsoft.Identity.Client.Broker",
       "assemblyName": "Microsoft.Identity.Client.Broker",
       "targetFramework": "net8.0",
-      "versionSyntax": "exact",
+      "classification": "preload",
+      "versionPolicy": "minorPatchFloat",
       "sourceModules": [
         "Az.Accounts",
         "Microsoft.Graph.Authentication",
@@ -79,7 +107,8 @@
       "packageName": "Microsoft.Identity.Client.Extensions.Msal",
       "assemblyName": "Microsoft.Identity.Client.Extensions.Msal",
       "targetFramework": "net8.0",
-      "versionSyntax": "exact",
+      "classification": "preload",
+      "versionPolicy": "minorPatchFloat",
       "sourceModules": [
         "Az.Accounts",
         "Microsoft.Graph.Authentication",

--- a/src/DLLPickle.Build/DLLPickle.csproj
+++ b/src/DLLPickle.Build/DLLPickle.csproj
@@ -19,10 +19,15 @@
          compatible Azure.Core themselves on .NET 8, so the preload is unnecessary for them.
          The original net48-only Azure.Core preload (#183) does not apply to the net8.0 baseline.
          Tracked as report-only in build/dependency-policy.json. -->
-    <PackageReference Include="Microsoft.Identity.Client" Version="[4.84.1]" />
-    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="[4.84.1]" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="[4.84.1]" />
-    <PackageReference Include="Microsoft.Identity.Client.NativeInterop" Version="[0.20.6]" />
+    <!-- MSAL + broker line: major-locked floating (N.*) so Dependabot manages minor/patch updates
+         within the major (gated by the upstream-compatibility checks); major bumps stay a manual,
+         reviewed edit. The lock file pins the concrete resolved version. NativeInterop floats 0.*
+         so it tracks whatever the resolved broker requires. See build/dependency-policy.json
+         (versionPolicy: minorPatchFloat) and docs/Architecture.md. -->
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.*" />
+    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.*" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.*" />
+    <PackageReference Include="Microsoft.Identity.Client.NativeInterop" Version="0.*" />
     <PackageReference Include="Microsoft.IdentityModel.Abstractions" Version="8.*" />
     <PackageReference Include="Microsoft.IdentityModel.Logging" Version="8.*" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.*" />

--- a/src/DLLPickle.Build/packages.lock.json
+++ b/src/DLLPickle.Build/packages.lock.json
@@ -19,7 +19,7 @@
       },
       "Microsoft.Identity.Client": {
         "type": "Direct",
-        "requested": "[4.84.1, 4.84.1]",
+        "requested": "[4.*, )",
         "resolved": "4.84.1",
         "contentHash": "60+xPFQgNattMRnVksYten6wRUHNCDzjlJnerGF2C2xXpsCkUHgLE4jkaoXKuIPtmq4zubs09I6sIsWVpZBsSA==",
         "dependencies": {
@@ -29,7 +29,7 @@
       },
       "Microsoft.Identity.Client.Broker": {
         "type": "Direct",
-        "requested": "[4.84.1, 4.84.1]",
+        "requested": "[4.*, )",
         "resolved": "4.84.1",
         "contentHash": "A5SCBuLqf/eHfgc+fx/1uBj7wBKFaWXJZ/lQ/skm+8v2L+tYe8lTeqQ0hNiTqYFjyk44KGnWD4FDLEkONN7zBg==",
         "dependencies": {
@@ -39,7 +39,7 @@
       },
       "Microsoft.Identity.Client.Extensions.Msal": {
         "type": "Direct",
-        "requested": "[4.84.1, 4.84.1]",
+        "requested": "[4.*, )",
         "resolved": "4.84.1",
         "contentHash": "DnfUWKfkRnSIXEnMWKHc9q893Xqaaal26PkznsIdC/IR8P2BaYsgEItoK9wSU++UNO/TapLg6XydI5XwcdykBQ==",
         "dependencies": {
@@ -49,7 +49,7 @@
       },
       "Microsoft.Identity.Client.NativeInterop": {
         "type": "Direct",
-        "requested": "[0.20.6, 0.20.6]",
+        "requested": "[0.*, )",
         "resolved": "0.20.6",
         "contentHash": "noyfdMfVxyWpM6xUDmlW6gUvZ5ci24z7Qoy15JvynTQfZV5vTD2NEdsnT5Gy4ngViwgdIp5iRjRy10jAKXFAgw=="
       },

--- a/tests/Unit/DependencyAutomation.Tests.ps1
+++ b/tests/Unit/DependencyAutomation.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Dependency automation tooling' -Tag 'Unit' {
                 }
             )
             trackedAssemblies = @($AssemblyName)
-            exactPins = @()
+            preload = @()
             blockedPreloadAssemblies = @()
         } | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $PolicyPath -Encoding UTF8
 
@@ -43,33 +43,35 @@ Describe 'Dependency automation tooling' -Tag 'Unit' {
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Contoso.CappedLibrary" Version="[1.51.1]" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="[4.82.1]" />
+    <PackageReference Include="Contoso.CappedLibrary" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" />
   </ItemGroup>
 </Project>
 '@ | Set-Content -LiteralPath $ProjectPath -Encoding UTF8
 
         $PolicyPath = Join-Path -Path $TestDrive -ChildPath 'policy.json'
         @{
-            exactPins = @(
+            preload = @(
                 @{
                     packageName = 'Contoso.CappedLibrary'
                     assemblyName = 'Contoso.CappedLibrary'
                     targetFramework = 'net8.0'
-                    versionSyntax = 'exact'
+                    classification = 'preload'
+                    versionPolicy = 'minorPatchFloat'
                     maximumPackageVersion = '1.50.0'
                     sourceModules = @('Microsoft.Graph.Authentication', 'MicrosoftTeams')
                     updateMode = 'candidatePullRequest'
-                    reason = 'Synthetic exact pin test.'
+                    reason = 'Synthetic capped preload test.'
                 }
                 @{
                     packageName = 'Microsoft.Identity.Client'
                     assemblyName = 'Microsoft.Identity.Client'
                     targetFramework = 'net8.0'
-                    versionSyntax = 'exact'
+                    classification = 'preload'
+                    versionPolicy = 'minorPatchFloat'
                     sourceModules = @('Az.Accounts', 'Microsoft.Graph.Authentication')
                     updateMode = 'candidatePullRequest'
-                    reason = 'Synthetic unconditional exact pin test.'
+                    reason = 'Synthetic floating preload test.'
                 }
             )
             blockedPreloadAssemblies = @(
@@ -141,11 +143,11 @@ Describe 'Dependency automation tooling' -Tag 'Unit' {
         $Report = & $script:UpdateScriptPath -InventoryPath $InventoryPath -PolicyPath $PolicyPath -ProjectPath $ProjectPath -OutputPath (Join-Path $TestDrive 'candidate-report.json') -Confirm:$false -WhatIf:$false
 
         $Report.ProjectChanged | Should -BeTrue
-        $Report.Changes[0].CandidateVersion | Should -Be '[1.50.0]'
+        $Report.Changes[0].CandidateVersion | Should -Be '1.*'
         $Report.Changes[0].SourceModule | Should -Be 'MicrosoftTeams'
         $Report.Warnings | Should -Contain "PackageReference 'Contoso.CappedLibrary' candidate '1.53.0' exceeds maximum '1.50.0' for target framework 'net8.0'; using maximum version."
-        Get-Content -LiteralPath $ProjectPath -Raw | Should -Match 'Version="\[1\.50\.0\]"'
-        Get-Content -LiteralPath $ProjectPath -Raw | Should -Match 'Include="Microsoft\.Identity\.Client" Version="\[4\.83\.1\]"'
+        Get-Content -LiteralPath $ProjectPath -Raw | Should -Match 'Include="Contoso\.CappedLibrary" Version="1\.\*"'
+        Get-Content -LiteralPath $ProjectPath -Raw | Should -Match 'Include="Microsoft\.Identity\.Client" Version="4\.\*"'
         @($Report.BlockedFindings) | Should -HaveCount 1
         $Report.BlockedFindings[0].AssemblyName | Should -Be 'Microsoft.OData.Core'
     }

--- a/tools/Update-DLLPickleDependencyPins.ps1
+++ b/tools/Update-DLLPickleDependencyPins.ps1
@@ -4,9 +4,11 @@
 
 .DESCRIPTION
     Reads an upstream compatibility inventory and dependency policy, compares
-    exact-pin rules with src/DLLPickle.Build/DLLPickle.csproj, updates supported
+    preload rules with src/DLLPickle.Build/DLLPickle.csproj, updates supported
     package references when upstream module assembly identities require it, and
-    writes a JSON candidate report. Blocked preload families are reported but not
+    writes a JSON candidate report. A preload entry whose versionPolicy is
+    'minorPatchFloat' is written as a floating 'N.*' reference; otherwise an exact
+    '[x.y.z]' reference is written. Blocked preload families are reported but not
     applied.
 
 .PARAMETER InventoryPath
@@ -142,7 +144,7 @@ $ProjectChanged = $false
 $Changes = New-Object System.Collections.Generic.List[object]
 $Warnings = New-Object System.Collections.Generic.List[string]
 
-foreach ($Pin in @($Policy.exactPins)) {
+foreach ($Pin in @($Policy.preload)) {
     $SourceModuleLookup = @{}
     foreach ($SourceModule in @($Pin.sourceModules)) {
         $SourceModuleLookup[[string]$SourceModule] = $true
@@ -192,7 +194,11 @@ foreach ($Pin in @($Policy.exactPins)) {
         }
     }
 
-    $FormattedVersion = if ([string]$Pin.versionSyntax -eq 'exact') { '[{0}]' -f $TargetVersion } else { $TargetVersion }
+    $VersionPolicy = if ($Pin.versionPolicy) { [string]$Pin.versionPolicy } else { 'exact' }
+    $FormattedVersion = switch ($VersionPolicy) {
+        'minorPatchFloat' { '{0}.*' -f ([version]$TargetVersion).Major }
+        default { '[{0}]' -f $TargetVersion }
+    }
     $CurrentReference = Get-DLLPickleCurrentPackageReference -ProjectContent $ProjectContent -PackageName ([string]$Pin.packageName) -TargetFramework ([string]$Pin.targetFramework)
 
     if (-not $CurrentReference) {


### PR DESCRIPTION
## Summary

Completes the **2.1.0 realization batch** from the [needs-analysis plan](docs/superpowers/plans/2026-05-31-dll-needs-analysis.md) — the dependency-management/maintainability work that earns the minor bump.

> **⚠️ The bundled assembly versions are identical to 2.0.2.** Floating `4.*`/`0.*` resolve to the same MSAL `4.84.1` / NativeInterop `0.20.6` (the current latest within their majors), and IdentityModel was already `8.*`. So the **published module bytes don't change** — this release is about *how dependencies are managed and validated going forward*, not runtime behavior. The runtime is already covered by the 2.0.2 validation.

### What's in it
- **A4** — `dependency-policy.json` schema migrated: `exactPins` → classified `preload` entries with `versionPolicy`.
- **A5** — the policy now records the **full, evidence-backed** preload/block classification (9 preload, 9 block) for every tracked assembly, the four-module target scenario, and the drift **baseline** (module versions + conflict-surface fingerprint).
- **A6** — MSAL/broker pins floated to major-locked (`N.*`) so **Dependabot** manages minor/patch within the major (gated by the upstream-compat checks). Resolved versions unchanged.
- **B2** — a **conflict-surface drift gate** in the Upstream-Compatibility workflow: opens an issue when the surface fingerprint diverges from the baseline.
- **Release-trigger fix** — added `src/DLLPickle.Build/**` + `build/**` to the Release-and-Publish `paths` (the gap that kept #221 from auto-releasing).

(The agent-oriented `docs/Architecture.md` blueprint and the analysis tooling landed earlier in #220/#219.)

### Validation
`Invoke-Build -Task Analyze,Test` → 4 tasks, 0 errors (1 benign `InvalidLibrary` fixture). `IssueReproTest` integration 9/9 (incl. the Azure.Core + #193 regression guards). Policy JSON validates; dependency-automation unit tests green.

### Versioning note
`feat(policy):` is in the history, so `version_bump=auto` (or `minor`) computes **2.1.0**. Not auto-merged — leaving the merge + the publish decision to you (see the bundle-identical note above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
