### PR TITLE
fix(ci): address Codex review of the 2.1.0 drift gate and dependency tooling

### DIFF
--- a/.github/workflows/Upstream-Compatibility.yml
+++ b/.github/workflows/Upstream-Compatibility.yml
@@ -65,7 +65,10 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $Changed = git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- src/DLLPickle.Build/packages.lock.json src/DLLPickle.Build/DLLPickle.csproj
+          # Compare against the PR base SHA from the event context (always present in fetch-depth:0
+          # history); avoids relying on origin/<base> being fetched as a named ref or on a merge-base.
+          $BaseSha = '${{ github.event.pull_request.base.sha }}'
+          $Changed = git diff --name-only $BaseSha HEAD -- src/DLLPickle.Build/packages.lock.json src/DLLPickle.Build/DLLPickle.csproj
           $IsDependencyChange = -not [string]::IsNullOrWhiteSpace(($Changed | Out-String))
           "is_dependency_change=$($IsDependencyChange.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 

--- a/.github/workflows/Upstream-Compatibility.yml
+++ b/.github/workflows/Upstream-Compatibility.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
@@ -57,6 +59,42 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           Invoke-Build -File ./build/DLLPickle.Build.ps1 -Task Analyze,Test
+
+      - name: Detect dependency change
+        id: depchange
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $Changed = git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- src/DLLPickle.Build/packages.lock.json src/DLLPickle.Build/DLLPickle.csproj
+          $IsDependencyChange = -not [string]::IsNullOrWhiteSpace(($Changed | Out-String))
+          "is_dependency_change=$($IsDependencyChange.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Drift gate for dependency PRs
+        if: steps.depchange.outputs.is_dependency_change == 'true'
+        shell: pwsh
+        run: |
+          # A dependency PR (Dependabot bump of the lock/csproj) can change the bundled preload set.
+          # Recompute the upstream conflict surface and block the PR if it drifted from the recorded
+          # baseline, so an auto-merge cannot advance a bundle change before the preload decision is
+          # re-adjudicated. Non-dependency PRs skip this (and its module-download cost).
+          $ErrorActionPreference = 'Stop'
+          ./tools/Get-DLLPickleUpstreamInventory.ps1 `
+            -PolicyPath ./build/dependency-policy.json `
+            -ModuleCachePath ./artifacts/upstreamCompatibility/modules `
+            -OutputPath ./artifacts/upstreamCompatibility/upstream-inventory.json `
+            -Force
+          ./tools/New-DLLPickleConflictMatrix.ps1 `
+            -InventoryPath ./artifacts/upstreamCompatibility/upstream-inventory.json `
+            -OutputPath ./artifacts/upstreamCompatibility/conflict-matrix.json | Out-Null
+          $policy = Get-Content ./build/dependency-policy.json -Raw | ConvertFrom-Json
+          $current = Get-Content ./artifacts/upstreamCompatibility/conflict-matrix.json -Raw | ConvertFrom-Json
+          $fingerprint = [string]$current.Fingerprint
+          $baseline = [string]$policy.baseline.conflictSurfaceFingerprint
+          if ($fingerprint -ne $baseline) {
+            Write-Host "::error::Conflict surface changed (baseline '$baseline' -> '$fingerprint') on a dependency PR. Do not auto-merge: re-adjudicate the preload decision and update build/dependency-policy.json (classification + evidence + baseline) per docs/Architecture.md section 8."
+            throw 'Conflict-surface drift detected on a dependency PR; blocking auto-merge.'
+          }
+          Write-Host "Conflict surface unchanged (fingerprint '$fingerprint'); dependency bump is safe to merge."
 
   scheduled-upstream-compatibility:
     name: Validate latest upstream module compatibility
@@ -107,8 +145,10 @@ jobs:
           $policy = Get-Content ./build/dependency-policy.json -Raw | ConvertFrom-Json
           $current = Get-Content ./artifacts/upstreamCompatibility/conflict-matrix.json -Raw | ConvertFrom-Json
           $surface = @($current.ConflictSurface | Sort-Object)
-          $bytes = [System.Text.Encoding]::UTF8.GetBytes(($surface -join '|'))
-          $fingerprint = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::HashData($bytes)).Replace('-', '').ToLowerInvariant()
+          # Versions-aware fingerprint produced by New-DLLPickleConflictMatrix (single source of the
+          # algorithm) so a within-major version move on a still-conflicting assembly is detected,
+          # not just name-set changes. (ALC-ownership drift is the runtime-probe / maintainer tier.)
+          $fingerprint = [string]$current.Fingerprint
           $baseline = [string]$policy.baseline.conflictSurfaceFingerprint
           if ($fingerprint -ne $baseline) {
             Write-Host "::warning::Conflict surface changed (baseline '$baseline' -> '$fingerprint'). The preload decision in build/dependency-policy.json needs human review."
@@ -134,6 +174,7 @@ jobs:
           }
 
       - name: Generate candidate dependency updates
+        if: steps.drift.outputs.drift != 'true'
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -145,6 +186,7 @@ jobs:
             -Restore
 
       - name: Validate candidate update
+        if: steps.drift.outputs.drift != 'true'
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -152,6 +194,7 @@ jobs:
           Invoke-Build -File ./build/DLLPickle.Build.ps1 -Task IssueReproTest
 
       - name: Detect generated changes
+        if: steps.drift.outputs.drift != 'true'
         id: generated_changes
         shell: pwsh
         run: |
@@ -160,7 +203,7 @@ jobs:
           "has_changes=$($Changed.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Create candidate pull request
-        if: steps.generated_changes.outputs.has_changes == 'true' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.create_pull_request))
+        if: steps.drift.outputs.drift != 'true' && steps.generated_changes.outputs.has_changes == 'true' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.create_pull_request))
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Working on updates to replace PlatyPS documentation creation with the new Microsoft.PowerShell.PlatyPS module. (PRs and other help would be welcomed!)
 
+## [2.1.1] - 2026-05-31
+
+> Addresses the Codex review of 2.1.0. Repo-side hardening of the drift gate and dependency tooling — **no change to the published module bundle**.
+
+### Fixed
+
+- **Drift gate halts the candidate pipeline.** When the scheduled Upstream-Compatibility run detects a changed conflict surface, it now skips candidate-update generation and the automated dependency PR (flagging for human re-adjudication) instead of advancing preload changes against a stale baseline.
+- **`maximumPackageVersion` caps are preserved.** A capped `minorPatchFloat` preload entry is now written as an exact `[x.y.z]` pinned at the cap, instead of an unbounded `N.*` that would let restore resolve above the maximum.
+- **Versions-aware drift fingerprint.** The fingerprint is computed by `New-DLLPickleConflictMatrix` from each conflicting assembly's name **and** versions, so a within-major version move on a still-conflicting assembly is detected — not just name-set changes. (ALC-ownership drift remains the runtime-probe / maintainer tier.)
+- **Drift gate runs on dependency PRs.** Dependabot lock/csproj bumps now recompute the conflict surface and block auto-merge if it drifted from the baseline, instead of the gate only running on the scheduled job.
+- **Blocked `Microsoft.Extensions.*` transitives are tracked.** They are added to `trackedAssemblies` so the inventory/automation surfaces them; the drift baseline is recomputed accordingly.
+
 ## [2.1.0] - 2026-05-31
 
 > The bundled assembly versions are **unchanged** from 2.0.2 (the floating ranges resolve to the same MSAL 4.84.1 / NativeInterop 0.20.6 — the current latest within their majors). This release is about **how dependencies are managed and validated going forward**, not a runtime change.
@@ -281,7 +293,8 @@ Full Changelog: [v0.2.5...v0.2.6](https://github.com/SamErde/DLLPickle/compare/v
 
 - Initial release.
 
-[Unreleased]: https://github.com/SamErde/DLLPickle/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/SamErde/DLLPickle/compare/v2.1.1...HEAD
+[2.1.1]: https://github.com/SamErde/DLLPickle/tag/v2.1.1
 [2.1.0]: https://github.com/SamErde/DLLPickle/tag/v2.1.0
 [2.0.2]: https://github.com/SamErde/DLLPickle/tag/v2.0.2
 [2.0.1]: https://github.com/SamErde/DLLPickle/tag/v2.0.1

--- a/build/dependency-policy.json
+++ b/build/dependency-policy.json
@@ -42,6 +42,8 @@
     "Microsoft.IdentityModel.Logging",
     "Microsoft.IdentityModel.Tokens",
     "System.IdentityModel.Tokens.Jwt",
+    "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "Microsoft.Extensions.Logging.Abstractions",
     "Microsoft.OData.Core",
     "Microsoft.OData.Edm",
     "Microsoft.Spatial"
@@ -74,9 +76,10 @@
       "Az.Accounts": "5.4.0",
       "Microsoft.Graph.Authentication": "2.37.0",
       "ExchangeOnlineManagement": "3.9.2",
-      "MicrosoftTeams": "7.8.0"
+      "MicrosoftTeams": "7.8.0",
+      "Az.Storage": "9.6.1"
     },
-    "conflictSurfaceFingerprint": "6a0ea4e7b401c8d3debb081b534d63bb7edf7c5ee61eea21a50ab126feae13ca"
+    "conflictSurfaceFingerprint": "b9fd2e1c135ecc76438f43eb56ce6db368999240fc25ab0140c40b1ab18359cd"
   },
   "preload": [
     {

--- a/tests/Unit/ConflictMatrix.Tests.ps1
+++ b/tests/Unit/ConflictMatrix.Tests.ps1
@@ -62,4 +62,35 @@ Describe 'New-DLLPickleConflictMatrix' -Tag 'Unit' {
         @($AzureCore.ShippedBy).Count | Should -Be 1
         @($Matrix.ConflictSurface) | Should -BeNullOrEmpty
     }
+
+    It 'produces a deterministic, versions-aware Fingerprint over the conflict surface' {
+        $Matrix = & $ScriptPath -Inventory (Get-TestInventory)
+        $Matrix.Fingerprint | Should -Not -BeNullOrEmpty
+        # Deterministic: same input -> same fingerprint.
+        ($Matrix.Fingerprint) | Should -Be (& $ScriptPath -Inventory (Get-TestInventory)).Fingerprint
+    }
+
+    It 'changes the Fingerprint when a surface assembly version moves but the names do not' {
+        # Same conflict-surface NAMES (Azure.Core diverges in both), but one version differs.
+        # A names-only hash would collide; the versions-aware fingerprint must differ.
+        $MakeInventory = {
+            param($GraphAzureCoreVersion)
+            [PSCustomObject]@{
+                Modules = @(
+                    [PSCustomObject]@{
+                        Name              = 'Az.Accounts'
+                        TrackedAssemblies = @([PSCustomObject]@{ Name = 'Azure.Core'; Version = '1.50.0.0' })
+                    }
+                    [PSCustomObject]@{
+                        Name              = 'Microsoft.Graph.Authentication'
+                        TrackedAssemblies = @([PSCustomObject]@{ Name = 'Azure.Core'; Version = $GraphAzureCoreVersion })
+                    }
+                )
+            }
+        }
+        $base = & $ScriptPath -Inventory (& $MakeInventory '1.46.0.0')
+        $moved = & $ScriptPath -Inventory (& $MakeInventory '1.51.1.0')
+        @($base.ConflictSurface) | Should -Be @($moved.ConflictSurface)   # same names
+        $base.Fingerprint | Should -Not -Be $moved.Fingerprint            # different fingerprint
+    }
 }

--- a/tests/Unit/DependencyAutomation.Tests.ps1
+++ b/tests/Unit/DependencyAutomation.Tests.ps1
@@ -143,10 +143,12 @@ Describe 'Dependency automation tooling' -Tag 'Unit' {
         $Report = & $script:UpdateScriptPath -InventoryPath $InventoryPath -PolicyPath $PolicyPath -ProjectPath $ProjectPath -OutputPath (Join-Path $TestDrive 'candidate-report.json') -Confirm:$false -WhatIf:$false
 
         $Report.ProjectChanged | Should -BeTrue
-        $Report.Changes[0].CandidateVersion | Should -Be '1.*'
+        # Capped minorPatchFloat must NOT float (a floating 1.* would resolve above the 1.50.0 cap);
+        # it is pinned exactly at the capped version. The uncapped MSAL entry floats as 4.*.
+        $Report.Changes[0].CandidateVersion | Should -Be '[1.50.0]'
         $Report.Changes[0].SourceModule | Should -Be 'MicrosoftTeams'
         $Report.Warnings | Should -Contain "PackageReference 'Contoso.CappedLibrary' candidate '1.53.0' exceeds maximum '1.50.0' for target framework 'net8.0'; using maximum version."
-        Get-Content -LiteralPath $ProjectPath -Raw | Should -Match 'Include="Contoso\.CappedLibrary" Version="1\.\*"'
+        Get-Content -LiteralPath $ProjectPath -Raw | Should -Match 'Include="Contoso\.CappedLibrary" Version="\[1\.50\.0\]"'
         Get-Content -LiteralPath $ProjectPath -Raw | Should -Match 'Include="Microsoft\.Identity\.Client" Version="4\.\*"'
         @($Report.BlockedFindings) | Should -HaveCount 1
         $Report.BlockedFindings[0].AssemblyName | Should -Be 'Microsoft.OData.Core'

--- a/tools/New-DLLPickleConflictMatrix.ps1
+++ b/tools/New-DLLPickleConflictMatrix.ps1
@@ -64,10 +64,25 @@ $AssemblyRows = foreach ($Name in ($ByAssembly.Keys | Sort-Object)) {
     }
 }
 
+# Versions-aware fingerprint over the conflict surface. Each diverging assembly contributes its
+# name AND its sorted distinct versions, so a material change where the same assemblies stay in
+# conflict but their versions move (e.g. an upstream module bumps within-major) changes the hash.
+# This is the single source of the drift fingerprint consumed by the Upstream-Compatibility workflow
+# and the recorded baseline in build/dependency-policy.json. (ALC ownership is not included: it is
+# null in the static inventory and is only known from the runtime probe / maintainer adjudication.)
+$SurfaceRows = @(
+    $AssemblyRows | Where-Object Diverges | Sort-Object Name | ForEach-Object {
+        '{0}={1}' -f $_.Name, (@($_.Versions | Sort-Object) -join ',')
+    }
+)
+$FingerprintBytes = [System.Text.Encoding]::UTF8.GetBytes(($SurfaceRows -join '|'))
+$Fingerprint = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::HashData($FingerprintBytes)).Replace('-', '').ToLowerInvariant()
+
 $Matrix = [PSCustomObject]@{
     GeneratedAtUtc  = $null   # stamped by the caller; avoids non-deterministic test output
     Assemblies      = @($AssemblyRows)
     ConflictSurface = @($AssemblyRows | Where-Object Diverges | ForEach-Object Name)
+    Fingerprint     = $Fingerprint
 }
 
 if ($OutputPath) {

--- a/tools/Update-DLLPickleDependencyPins.ps1
+++ b/tools/Update-DLLPickleDependencyPins.ps1
@@ -180,7 +180,8 @@ foreach ($Pin in @($Policy.preload)) {
         Sort-Object -Property { [version]$_.AssemblyVersion } -Descending |
         Select-Object -First 1
     $TargetVersion = [string]$TargetAssembly.PackageVersion
-    if (-not [string]::IsNullOrWhiteSpace([string]$Pin.maximumPackageVersion)) {
+    $IsCapped = -not [string]::IsNullOrWhiteSpace([string]$Pin.maximumPackageVersion)
+    if ($IsCapped) {
         $MaximumPackageVersion = [string]$Pin.maximumPackageVersion
         if ([version]$TargetVersion -gt [version]$MaximumPackageVersion) {
             $Warnings.Add((
@@ -195,9 +196,13 @@ foreach ($Pin in @($Policy.preload)) {
     }
 
     $VersionPolicy = if ($Pin.versionPolicy) { [string]$Pin.versionPolicy } else { 'exact' }
-    $FormattedVersion = switch ($VersionPolicy) {
-        'minorPatchFloat' { '{0}.*' -f ([version]$TargetVersion).Major }
-        default { '[{0}]' -f $TargetVersion }
+    # A minorPatchFloat rule normally writes a floating 'N.*' reference. But when the entry also
+    # declares maximumPackageVersion, a floating reference would let restore resolve ABOVE the cap,
+    # so a capped entry is written as an exact '[x.y.z]' pinned at the capped target to enforce it.
+    $FormattedVersion = if ($VersionPolicy -eq 'minorPatchFloat' -and -not $IsCapped) {
+        '{0}.*' -f ([version]$TargetVersion).Major
+    } else {
+        '[{0}]' -f $TargetVersion
     }
     $CurrentReference = Get-DLLPickleCurrentPackageReference -ProjectContent $ProjectContent -PackageName ([string]$Pin.packageName) -TargetFramework ([string]$Pin.targetFramework)
 


### PR DESCRIPTION
## Summary

Addresses all five Codex review comments left on #222 (the 2.1.0 release PR). The DLLPickle module bundle is **unchanged** — these are corrections to the upstream-compatibility automation and drift-detection tooling, so this ships as a patch (2.1.1).

## Codex comments resolved

| # | Comment | Fix |
|---|---------|-----|
| 1 | Automation should halt, not silently proceed, when conflict-surface drift is detected | The scheduled job's generate / validate / detect-changes / create-PR steps are now gated on `steps.drift.outputs.drift != 'true'`. On drift it opens (or comments on) a tracking issue and stops. |
| 2 | `Update-DLLPickleDependencyPins` could widen a capped pin to `N.*` | A `minorPatchFloat` entry that carries a `maximumPackageVersion` cap is now written as exact `[x.y.z]`, never unbounded `N.*`. |
| 3 | Drift fingerprint was name-set only — a version move on a still-conflicting assembly wouldn't trip it | `New-DLLPickleConflictMatrix` now emits a versions-aware `Fingerprint` (single source of the algorithm: SHA-256 over sorted `name=sorted-versions` of the diverging surface). Both workflow jobs read `$current.Fingerprint`. |
| 4 | Drift gate didn't run on dependency PRs (Dependabot bumps could auto-merge a bundle change) | `pr-smoke` gained `fetch-depth: 0`, a dependency-change detector (lock/csproj diff vs the PR base SHA), and a drift gate that `throw`s on drift for dependency PRs to block auto-merge. |
| 5 | The blocked `Microsoft.Extensions.*` transitives weren't tracked, so the automation couldn't surface them | Added `Microsoft.Extensions.DependencyInjection.Abstractions` and `Microsoft.Extensions.Logging.Abstractions` to `trackedAssemblies` (now 18) and recomputed the drift baseline. |

## Baseline

The conflict-surface baseline in `build/dependency-policy.json` was recomputed from a fresh inventory (versions-aware fingerprint, expanded tracked set):

`conflictSurfaceFingerprint = b9fd2e1c135ecc76438f43eb56ce6db368999240fc25ab0140c40b1ab18359cd`

## Validation

- `Invoke-Build Analyze,Test` — succeeded (4 tasks, 0 errors); analyzer clean on both modified tools.
- Unit suite 8/8, including two new fingerprint tests (deterministic; changes on a within-major version move).
- Policy JSON validates: tracked = 18, preload = 9, blocked = 9.
- Both workflow YAMLs parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
