### PR TITLE
fix(ci): address Codex follow-up review on #223 (drift fingerprint, policy scope, gate wording)

### DIFF
--- a/.github/workflows/Upstream-Compatibility.yml
+++ b/.github/workflows/Upstream-Compatibility.yml
@@ -72,14 +72,23 @@ jobs:
           $IsDependencyChange = -not [string]::IsNullOrWhiteSpace(($Changed | Out-String))
           "is_dependency_change=$($IsDependencyChange.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
-      - name: Drift gate for dependency PRs
+      - name: Upstream conflict-surface freshness check for dependency PRs
         if: steps.depchange.outputs.is_dependency_change == 'true'
         shell: pwsh
         run: |
-          # A dependency PR (Dependabot bump of the lock/csproj) can change the bundled preload set.
-          # Recompute the upstream conflict surface and block the PR if it drifted from the recorded
-          # baseline, so an auto-merge cannot advance a bundle change before the preload decision is
-          # re-adjudicated. Non-dependency PRs skip this (and its module-download cost).
+          # Freshness check, NOT a bundle validation. When a dependency PR (Dependabot bump of the
+          # lock/csproj) is open, recompute the UPSTREAM module conflict surface and block the PR if it
+          # drifted from the recorded baseline: a stale baseline means the preload/block decision the
+          # bundle is built against may no longer hold and must be re-adjudicated before merge.
+          #
+          # This step does NOT validate the bumped bundle itself. A self-bump of DLLPickle's own NuGet
+          # references does not change what the upstream modules ship, so it will not move this
+          # fingerprint. The bumped bundle is validated separately by the "Build Module" workflow, which
+          # on every PR touching src/** runs the full build under --locked-mode plus the #193 / Azure.Core
+          # integration repro guards, bounded by the csproj floating-with-cap constraints. For auto-merge
+          # to actually wait on those signals, the Build Module and Dependency Review checks must be
+          # configured as required status checks (see Dependabot-Auto-Approve.yml).
+          # Non-dependency PRs skip this step (and its module-download cost).
           $ErrorActionPreference = 'Stop'
           ./tools/Get-DLLPickleUpstreamInventory.ps1 `
             -PolicyPath ./build/dependency-policy.json `
@@ -94,10 +103,10 @@ jobs:
           $fingerprint = [string]$current.Fingerprint
           $baseline = [string]$policy.baseline.conflictSurfaceFingerprint
           if ($fingerprint -ne $baseline) {
-            Write-Host "::error::Conflict surface changed (baseline '$baseline' -> '$fingerprint') on a dependency PR. Do not auto-merge: re-adjudicate the preload decision and update build/dependency-policy.json (classification + evidence + baseline) per docs/Architecture.md section 8."
-            throw 'Conflict-surface drift detected on a dependency PR; blocking auto-merge.'
+            Write-Host "::error::Upstream conflict surface changed (baseline '$baseline' -> '$fingerprint') while a dependency PR is open. The preload/block decision this bundle is built against may be stale: re-adjudicate and update build/dependency-policy.json (classification + evidence + baseline) per docs/Architecture.md section 8 before merging."
+            throw 'Upstream conflict-surface drift detected on a dependency PR; blocking auto-merge until re-adjudicated.'
           }
-          Write-Host "Conflict surface unchanged (fingerprint '$fingerprint'); dependency bump is safe to merge."
+          Write-Host "Upstream conflict surface unchanged (fingerprint '$fingerprint'); the recorded preload/block baseline still holds. (Bundle correctness is validated separately by the Build Module workflow.)"
 
   scheduled-upstream-compatibility:
     name: Validate latest upstream module compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Working on updates to replace PlatyPS documentation creation with the new Microsoft.PowerShell.PlatyPS module. (PRs and other help would be welcomed!)
 
+## [2.1.2] - 2026-06-01
+
+> Follow-up Codex review of #223. Refines the 2.1.1 drift tooling and policy documentation — **no change to the published module bundle**.
+
+### Fixed
+
+- **Drift fingerprint is now contributor-aware.** `New-DLLPickleConflictMatrix` hashes each conflicting assembly's name, its versions, **and** the set of modules that ship it (`ShippedBy`), so a change in which modules contribute to a conflict (at the same version set) also trips drift for re-adjudication — not just name- or version-set changes. The recorded baseline is recomputed accordingly.
+- **Dependency-PR gate documented as an upstream-freshness check.** Corrected the step name, comments, and messages to make clear it validates that the upstream conflict surface still matches the baseline — *not* the bumped bundle (a self-bump does not move the upstream fingerprint). The bundle is validated by the Build Module workflow (full build under `--locked-mode` + the #193 / Azure.Core repro guards, bounded by the csproj caps); those checks must be required status checks for auto-merge to wait on them.
+- **Clarified `Microsoft.Extensions.*` tracking scope.** Recorded a `trackingScope` note on the blocked entries: Az.Resources (the observed #193 trigger) is not in `monitoredModules`, so its own copy is not inventoried; these assemblies are surfaced via the monitored Az.Accounts / Microsoft.Graph.Authentication that also bundle them.
+
 ## [2.1.1] - 2026-05-31
 
 > Addresses the Codex review of 2.1.0. Repo-side hardening of the drift gate and dependency tooling — **no change to the published module bundle**.
@@ -293,7 +303,8 @@ Full Changelog: [v0.2.5...v0.2.6](https://github.com/SamErde/DLLPickle/compare/v
 
 - Initial release.
 
-[Unreleased]: https://github.com/SamErde/DLLPickle/compare/v2.1.1...HEAD
+[Unreleased]: https://github.com/SamErde/DLLPickle/compare/v2.1.2...HEAD
+[2.1.2]: https://github.com/SamErde/DLLPickle/tag/v2.1.2
 [2.1.1]: https://github.com/SamErde/DLLPickle/tag/v2.1.1
 [2.1.0]: https://github.com/SamErde/DLLPickle/tag/v2.1.0
 [2.0.2]: https://github.com/SamErde/DLLPickle/tag/v2.0.2

--- a/build/dependency-policy.json
+++ b/build/dependency-policy.json
@@ -79,7 +79,7 @@
       "MicrosoftTeams": "7.8.0",
       "Az.Storage": "9.6.1"
     },
-    "conflictSurfaceFingerprint": "b9fd2e1c135ecc76438f43eb56ce6db368999240fc25ab0140c40b1ab18359cd"
+    "conflictSurfaceFingerprint": "b04622cba725f5cb9c1cee4bb928879564ff6e700b574f92f744673151b90798"
   },
   "preload": [
     {
@@ -338,7 +338,8 @@
         "alcOwner": "Default (collision)",
         "basis": "Diagnostic 2026-05-31: DLLPickle preloaded 8.0.0 into the default ALC; PowerShell ships only Microsoft.Extensions.ObjectPool (not this); Az.Resources 9.x bundles its own copy -> 'assembly with same name is already loaded' on Import-Module Az.Resources. Fixed in 2.0.2.",
         "decidedOn": "2026-05-31",
-        "issue": "193"
+        "issue": "193",
+        "trackingScope": "Az.Resources is the observed #193 collision trigger but is NOT in monitoredModules, so the drift inventory does not see its copy or future version drift. This assembly is tracked because the monitored Az.Accounts and Microsoft.Graph.Authentication also bundle it (see sourceModules); the baseline therefore surfaces it via those modules, not via Az.Resources. Re-adjudicate manually if a future Az.Resources change is suspected, or add Az.Resources to monitoredModules to inventory it directly."
       }
     },
     {
@@ -356,7 +357,8 @@
         "alcOwner": "Default (collision)",
         "basis": "Excluded alongside DependencyInjection.Abstractions in 2.0.2. Microsoft.IdentityModel.Tokens still loads without it bundled (resolves lazily / supplied by the consuming service modules).",
         "decidedOn": "2026-05-31",
-        "issue": "193"
+        "issue": "193",
+        "trackingScope": "Az.Resources is the observed #193 collision trigger but is NOT in monitoredModules, so the drift inventory does not see its copy or future version drift. This assembly is tracked because the monitored Az.Accounts and Microsoft.Graph.Authentication also bundle it (see sourceModules); the baseline therefore surfaces it via those modules, not via Az.Resources. Re-adjudicate manually if a future Az.Resources change is suspected, or add Az.Resources to monitoredModules to inventory it directly."
       }
     },
     {

--- a/tests/Unit/ConflictMatrix.Tests.ps1
+++ b/tests/Unit/ConflictMatrix.Tests.ps1
@@ -93,4 +93,31 @@ Describe 'New-DLLPickleConflictMatrix' -Tag 'Unit' {
         @($base.ConflictSurface) | Should -Be @($moved.ConflictSurface)   # same names
         $base.Fingerprint | Should -Not -Be $moved.Fingerprint            # different fingerprint
     }
+
+    It 'changes the Fingerprint when the contributing modules change but the version set does not' {
+        # Same conflict-surface NAME (Azure.Core) and same VERSION SET {1.50, 1.46}, but a different
+        # set of contributing modules. A name+versions-only hash would collide; the contributor-aware
+        # fingerprint (ShippedBy) must differ because the preload/block adjudication is module-specific.
+        $MakeInventory = {
+            param($SecondModule)
+            [PSCustomObject]@{
+                Modules = @(
+                    [PSCustomObject]@{
+                        Name              = 'Az.Accounts'
+                        TrackedAssemblies = @([PSCustomObject]@{ Name = 'Azure.Core'; Version = '1.50.0.0' })
+                    }
+                    [PSCustomObject]@{
+                        Name              = $SecondModule
+                        TrackedAssemblies = @([PSCustomObject]@{ Name = 'Azure.Core'; Version = '1.46.0.0' })
+                    }
+                )
+            }
+        }
+        $viaGraph = & $ScriptPath -Inventory (& $MakeInventory 'Microsoft.Graph.Authentication')
+        $viaTeams = & $ScriptPath -Inventory (& $MakeInventory 'MicrosoftTeams')
+        @($viaGraph.ConflictSurface) | Should -Be @($viaTeams.ConflictSurface)   # same names
+        @($viaGraph.Assemblies | Where-Object Name -EQ 'Azure.Core').Versions |
+            Should -Be @($viaTeams.Assemblies | Where-Object Name -EQ 'Azure.Core').Versions   # same version set
+        $viaGraph.Fingerprint | Should -Not -Be $viaTeams.Fingerprint            # different contributors
+    }
 }

--- a/tools/New-DLLPickleConflictMatrix.ps1
+++ b/tools/New-DLLPickleConflictMatrix.ps1
@@ -64,15 +64,19 @@ $AssemblyRows = foreach ($Name in ($ByAssembly.Keys | Sort-Object)) {
     }
 }
 
-# Versions-aware fingerprint over the conflict surface. Each diverging assembly contributes its
-# name AND its sorted distinct versions, so a material change where the same assemblies stay in
-# conflict but their versions move (e.g. an upstream module bumps within-major) changes the hash.
+# Versions- and contributor-aware fingerprint over the conflict surface. Each diverging assembly
+# contributes its name, its sorted distinct versions, AND the sorted set of modules that ship it
+# (ShippedBy). Including versions catches a material change where the same assemblies stay in conflict
+# but their versions move (e.g. an upstream module bumps within-major). Including ShippedBy catches a
+# change in WHICH modules contribute to a conflict even when the version set is unchanged (e.g. one
+# module leaves a conflict as another joins at the same versions) -- the preload/block adjudication is
+# module-specific, so that contributor change also needs human review.
 # This is the single source of the drift fingerprint consumed by the Upstream-Compatibility workflow
 # and the recorded baseline in build/dependency-policy.json. (ALC ownership is not included: it is
 # null in the static inventory and is only known from the runtime probe / maintainer adjudication.)
 $SurfaceRows = @(
     $AssemblyRows | Where-Object Diverges | Sort-Object Name | ForEach-Object {
-        '{0}={1}' -f $_.Name, (@($_.Versions | Sort-Object) -join ',')
+        '{0}={1};by={2}' -f $_.Name, (@($_.Versions | Sort-Object) -join ','), (@($_.ShippedBy | Sort-Object) -join ',')
     }
 )
 $FingerprintBytes = [System.Text.Encoding]::UTF8.GetBytes(($SurfaceRows -join '|'))


### PR DESCRIPTION
## Summary

Addresses the **three follow-up Codex comments** on #223 (which was merged before Codex reviewed it, shipping 2.1.1). These refine the drift tooling and policy documentation — **no change to the published module bundle**. Ships as a patch (**2.1.2**).

Dispositions were confirmed with the maintainer before implementation.

## Codex follow-up comments resolved

| # | Comment | Disposition |
|---|---------|-------------|
| A | Dependency-PR gate validates upstream drift, not the bumped bundle | **Kept the gate, fixed the wording.** A self-bump never moves the upstream fingerprint, so the step is now correctly named/documented as an *upstream conflict-surface freshness check*. The bumped bundle is validated by the **Build Module** workflow (full build under `--locked-mode` + the #193 / Azure.Core repro guards, bounded by csproj floating-with-cap). Noted that those checks must be **required status checks** for `gh pr merge --auto` to wait on them. |
| B | Tracking `Microsoft.Extensions.*` is hollow — Az.Resources isn't monitored | **Softened the claim** rather than expanding the monitored set. Recorded a `trackingScope` note on the blocked entries: Az.Resources (the #193 trigger) isn't in `monitoredModules`, so its own copy isn't inventoried; the assemblies are surfaced via the monitored Az.Accounts / Microsoft.Graph.Authentication that also bundle them. |
| C | Fingerprint ignores *which* modules ship an assembly | **Added `ShippedBy`.** `New-DLLPickleConflictMatrix` now hashes name + versions + the contributing-module set, so a module entering/leaving a conflict at the same version set also trips drift. Baseline recomputed deterministically over the same cached inventory: `b04622cba725f5cb9c1cee4bb928879564ff6e700b574f92f744673151b90798`. Regression test added. |

## Validation

- `Invoke-Build Analyze,Test` — **4 tasks, 0 errors** (1 warning = the deliberate `InvalidLibrary.dll` negative-test fixture).
- ConflictMatrix unit suite **7/7** (new `ShippedBy` test included).
- Policy JSON valid (tracked 18 / preload 9 / blocked 9); baseline matches the matrix recompute over the cached inventory.

> Note: merging this PR touches `build/**`, which auto-triggers Release-and-Publish → **v2.1.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
