### PR TITLE
ci: trigger release+publish only on module-bundle changes

### DIFF
--- a/.github/workflows/Release-and-Publish.yml
+++ b/.github/workflows/Release-and-Publish.yml
@@ -5,11 +5,21 @@ on:
     types: [closed]
     branches:
       - main
+    # Auto-trigger a release+publish ONLY when the change affects the PUBLISHED module bundle.
+    # CI, policy, docs, tests, tooling, and build-script-only changes must NOT publish a new gallery
+    # version (they leave the shipped DLLs + module source byte-identical). The paths below are exactly
+    # the inputs that change the published artifact:
+    #   src/DLLPickle/**                       - module source (manifest, public/private functions)
+    #   src/DLLPickle.Build/DLLPickle.csproj   - declares the bundled DLL package references
+    #   src/DLLPickle.Build/packages.lock.json - the resolved bundled DLL versions
+    # Deliberately excluded: build/** (build scripts + dependency-policy.json), .github/** (CI),
+    # tests/**, tools/**, docs/**, *.md, and src/DLLPickle.Build/DLLPickle.sln - none change the bundle.
+    # Rare genuine packaging-logic changes (build/DLLPickle.Build.ps1) should be released with a
+    # manual workflow_dispatch run.
     paths:
       - "src/DLLPickle/**"
-      - "src/DLLPickle.Build/**"
-      - "build/**"
-      - "module/**"
+      - "src/DLLPickle.Build/DLLPickle.csproj"
+      - "src/DLLPickle.Build/packages.lock.json"
   workflow_dispatch:
     inputs:
       version_bump:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Working on updates to replace PlatyPS documentation creation with the new Microsoft.PowerShell.PlatyPS module. (PRs and other help would be welcomed!)
+- CI: Release-and-Publish now auto-triggers only on changes to the published module bundle (`src/DLLPickle/**`, `src/DLLPickle.Build/DLLPickle.csproj`, `src/DLLPickle.Build/packages.lock.json`). CI-, policy-, docs-, test-, and tooling-only changes no longer publish a new PowerShell Gallery version; release a genuine packaging-logic change via a manual `workflow_dispatch` run.
 
 ## [2.1.2] - 2026-06-01
 


### PR DESCRIPTION
## Summary

Stops CI/policy/docs-only changes from auto-publishing a new PowerShell Gallery version.

2.1.1 and 2.1.2 both published a **byte-identical bundle** — they were CI/tooling/policy refinements, not module changes — because the `Release-and-Publish` `pull_request` trigger matched `build/**` (which contains `dependency-policy.json`) and the broad `src/DLLPickle.Build/**` (which contains the `.sln`), plus `module/**`.

## Change

Narrows the trigger `paths` to **exactly the inputs that change the published artifact**:

```yaml
paths:
  - "src/DLLPickle/**"                       # module source (manifest, functions)
  - "src/DLLPickle.Build/DLLPickle.csproj"   # bundled DLL package references
  - "src/DLLPickle.Build/packages.lock.json" # resolved bundled DLL versions
```

Removed: `build/**`, `src/DLLPickle.Build/**` (now just the csproj + lock, not the `.sln`), and `module/**` (untracked — never matched anyway).

## Behavior after this change

| Change type | Auto-publishes? |
|---|---|
| Module source / dependency bump (csproj, lock) | ✅ yes |
| `build/dependency-policy.json`, CI workflows, docs, tests, tools | ❌ no |
| Packaging-logic change (`build/DLLPickle.Build.ps1`) | ❌ no — release via manual `workflow_dispatch` |

`workflow_dispatch` remains the escape hatch to publish deliberately for any reason.

> Merging this PR will **not** trigger a release (a workflow-file-only change matches none of the paths under either the old or new filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
