### PR TITLE
fix(ci): unblock the release workflow (reusable-workflow permission startup failure)

### DIFF
--- a/.github/workflows/Release-and-Publish.yml
+++ b/.github/workflows/Release-and-Publish.yml
@@ -315,6 +315,11 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      # Required by the called "Build Module.yml": its `changes` job declares pull-requests: read.
+      # A reusable workflow's jobs may not request permissions the caller did not grant, and GitHub
+      # validates this STATICALLY at startup -- even though `changes` is skipped on the release
+      # (workflow_call) path. Without granting it here the release run fails to start (startup_failure).
+      pull-requests: read
     with:
       ref: ${{ needs.analyze.outputs.release_sha }}
 


### PR DESCRIPTION
## Why

`Release-and-Publish` **startup_failed** on both `pull_request: closed` (run 26821404801) and `workflow_dispatch` (run 26821603517) after #228 merged, so **2.2.0 never published**. A startup failure means the workflow file is rejected before any job runs.

## Root cause

#228 added a `changes` job to the reusable **`Build Module.yml`** that declares:

```yaml
permissions:
  contents: read
  pull-requests: read
```

`Release-and-Publish.yml` calls that workflow via `uses: ./.github/workflows/Build Module.yml`, and its `build-and-test` caller granted only `contents: read` + `security-events: write`.

A reusable workflow's jobs **may not request permissions the caller did not grant** ([docs](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows): "permissions can only be maintained or reduced—not elevated"). GitHub validates this **statically at startup**, *before* any `if:` skip is evaluated — so even though `changes` is skipped on the `workflow_call` (release) path, its excess `pull-requests: read` request fails the entire run before it starts. That's why **both** triggers failed deterministically, while direct-PR runs of `Build Module.yml` (no caller cap) were unaffected. The 2.1.2 release (no `changes` job) worked.

## Fix

Grant `pull-requests: read` on the `build-and-test` caller so static validation passes. The permission is **unused** on the release path (the `changes` job is skipped there) and is read-only and minimal. Comment added explaining why a future reader must not remove it.

## Scope / safety

- CI-only change (`.github/workflows/**`) — it is excluded from the release path filter, so **merging this does not itself publish** a gallery version.
- After merge, 2.2.0 is cut by a manual `workflow_dispatch` of Release-and-Publish (or by the next bundle PR).

## Not in this PR

The unresolved Codex **P2** on #231 ("include the policy in release triggers") is a separate, valid concern about which *future* edits trigger a publish. Tracked and replied to on #231; addressed separately so this stays a focused startup fix.
