### PR TITLE
docs: slim the README for new users and refresh the first-level /docs files

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -31,14 +31,21 @@ For usage guidance, see [README.md](README.md) and [docs/index.md](docs/index.md
 
 DLLPickle follows [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`).
 Releases are cut automatically by the **Release-and-Publish** workflow, which
-derives the bump from [Conventional Commits](https://www.conventionalcommits.org/)
-since the last tag:
+derives the bump **solely from the [Conventional Commit](https://www.conventionalcommits.org/)
+prefixes** of the commits since the last tag (see
+[`.github/ci-scripts/Get-VersionBump.ps1`](.github/ci-scripts/Get-VersionBump.ps1)):
 
-| Bump | Trigger |
-| ---- | ------- |
-| **MAJOR** (`X.y.z`) | A breaking change (a `!` / `BREAKING CHANGE` commit), or a bundled MSAL **major** version increment. |
-| **MINOR** (`x.Y.z`) | A new feature (`feat:`), or a new / updated bundled dependency — including the automated MSAL and identity-library version bumps that are the module's core purpose. |
-| **PATCH** (`x.y.Z`) | Fixes (`fix:`), refactors, performance/logging tweaks, and other non-breaking corrections. |
+| Bump | Commit prefix |
+| ---- | ------------- |
+| **MAJOR** (`X.y.z`) | `BREAKING CHANGE:`, `breaking:`, or `major-release` |
+| **MINOR** (`x.Y.z`) | `feat:` (or `minor:`) |
+| **PATCH** (`x.y.Z`) | `fix:`, `perf:`, `refactor:`, `security:`, or `chore:` |
+
+The bump is decided by the commit prefix alone — there is **no** separate
+detection of dependency or MSAL version changes. Label dependency-update PRs
+accordingly: the automated MSAL / identity-library bumps that are the module's
+core purpose should land as `feat:` so they produce a **minor** release, and a
+bundled-library **major** jump should be committed as a breaking change.
 
 A new PowerShell Gallery version is published **only** when a change affects the
 published module bundle (`src/DLLPickle/**` or the bundled package set). CI-,

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -27,6 +27,24 @@ For usage guidance, see [README.md](README.md) and [docs/index.md](docs/index.md
 | **Major** (X.y.z) | Manual review | Explicit maintainer approval |
 | **Upstream PowerShell module drift** | Candidate PR or issue | Upstream Compatibility workflow |
 
+## Versioning
+
+DLLPickle follows [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`).
+Releases are cut automatically by the **Release-and-Publish** workflow, which
+derives the bump from [Conventional Commits](https://www.conventionalcommits.org/)
+since the last tag:
+
+| Bump | Trigger |
+| ---- | ------- |
+| **MAJOR** (`X.y.z`) | A breaking change (a `!` / `BREAKING CHANGE` commit), or a bundled MSAL **major** version increment. |
+| **MINOR** (`x.Y.z`) | A new feature (`feat:`), or a new / updated bundled dependency — including the automated MSAL and identity-library version bumps that are the module's core purpose. |
+| **PATCH** (`x.y.Z`) | Fixes (`fix:`), refactors, performance/logging tweaks, and other non-breaking corrections. |
+
+A new PowerShell Gallery version is published **only** when a change affects the
+published module bundle (`src/DLLPickle/**` or the bundled package set). CI-,
+docs-, policy-, and tooling-only changes do not trigger a release. See
+[CHANGELOG.md](CHANGELOG.md) for the released history.
+
 ## Upstream Compatibility Automation
 
 Dependabot tracks NuGet package releases, but DLLPickle also tracks the DLLs
@@ -58,6 +76,19 @@ candidate generation, restore, build, and issue reproduction tests pass.
 | `Microsoft.IdentityModel.JsonWebTokens` | `8.*` | JWT handling |
 | `Microsoft.IdentityModel.Tokens` | `8.*` | Token validation/processing |
 | `System.IdentityModel.Tokens.Jwt` | `8.*` | JWT handlers |
+
+### Upstream package documentation
+
+The libraries DLLPickle tracks for preloading are maintained and documented by
+their own code owners:
+
+- [Microsoft.Identity.Abstractions](https://www.nuget.org/packages/Microsoft.Identity.Abstractions)
+- [Microsoft.Identity.Client](https://www.nuget.org/packages/Microsoft.Identity.Client)
+- [Microsoft.IdentityModel.Abstractions](https://www.nuget.org/packages/Microsoft.IdentityModel.Abstractions)
+- [Microsoft.IdentityModel.JsonWebTokens](https://www.nuget.org/packages/Microsoft.IdentityModel.JsonWebTokens)
+- [Microsoft.IdentityModel.Logging](https://www.nuget.org/packages/Microsoft.IdentityModel.Logging)
+- [Microsoft.IdentityModel.Tokens](https://www.nuget.org/packages/Microsoft.IdentityModel.Tokens)
+- [System.IdentityModel.Tokens.Jwt](https://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt)
 
 ## Exact Pin Rationale
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ PowerShell 7.4 or later on Linux, macOS, or Windows.
 Install-Module DLLPickle -Scope CurrentUser
 ```
 
-Or, if you use **Microsoft.PowerShell.PSResourceGet**, run:
+Or, with **Microsoft.PowerShell.PSResourceGet**:
 
 ```powershell
 Install-PSResource -Name DLLPickle
@@ -33,138 +33,49 @@ Install-PSResource -Name DLLPickle
 
 ### Using
 
-Import the module, then run `Import-DPLibrary` before connecting to service modules.
+Import DLL Pickle and run `Import-DPLibrary` **before** connecting to other service modules — ideally as the first thing in your PowerShell profile, so it loads first in every session.
 
 ```powershell
 Import-Module DLLPickle
 Import-DPLibrary
 ```
 
-### Core Commands
+For diagnostic detail, add `-ShowLoaderExceptions -Verbose`.
 
-DLLPickle currently exports the following commands:
+### Commands
 
-- `Import-DPLibrary`: preload DLLPickle-managed assemblies in dependency-aware order.
-- `Get-DPConfig`: view your current DLLPickle configuration.
-- `Set-DPConfig`: update DLLPickle configuration (for example, show logo, skip libraries).
-- `Find-DLLInPSModulePath`: inspect module paths for matching DLLs.
-- `Get-ModuleImportCandidate`: determine which installed module version would import.
-- `Get-ModulesWithDependency`: list installed modules that package a target dependency.
-- `Get-ModulesWithVersionSortedIdentityClient`: compare modules by packaged `Microsoft.Identity.Client.dll` version.
+**Primary:**
 
-For complete syntax and examples, see:
+- `Import-DPLibrary` — preload DLLPickle-managed assemblies in dependency-aware order.
+- `Import-DPBaseProfile` — preload, then import the validated base-profile modules (Exchange Online, Teams, Graph, Az.Accounts) in a known-good order.
+- `Test-DPLibraryConflict` — report known-incompatible module pairs loaded in the current session, with the workaround.
+- `Get-DPConfig` / `Set-DPConfig` — view or change configuration (for example, show logo, skip libraries).
 
-- [docs index](docs/index.md)
-- [module command reference](docs/DLLPickle.md)
+**Inspection helpers:**
 
----
+- `Find-DLLInPSModulePath` — find DLLs across module paths, filtered by product metadata.
+- `Get-ModuleImportCandidate` — show which installed module version would import.
+- `Get-ModulesWithDependency` — list installed modules that package a given dependency.
+- `Get-ModulesWithVersionSortedIdentityClient` — compare modules by packaged `Microsoft.Identity.Client.dll` version.
 
-## 📝 Description
+Full syntax and examples: [docs index](docs/index.md) · [command reference](docs/DLLPickle.md).
 
-Let's start with a few FAQs:
+## 🥒 How It Works
 
-- **What does DLL Pickle actually *do*?**
+Many PowerShell modules — Az, Exchange Online, Microsoft Graph, Teams, and more — bundle their own copy of the Microsoft Authentication Library (MSAL) and related DLLs. A single PowerShell session can only load **one** version of a given DLL, so when two modules ship different versions you hit *"an assembly with the same name is already loaded"* and authentication breaks.
 
-  DLL Pickle pre-loads the newest version of the MSAL DLLs (and some of their transitive dependencies) that may be required by your other installed modules' and scripts' `Connect-*` cmdlets. (See the example below.)
+DLL Pickle preloads a current, compatible set of these assemblies **first**, so the "first one wins" rule works in your favor and the modules you load afterward reuse what's already there. A new DLL Pickle release is published automatically whenever a new MSAL version ships — so keep it updated and load it first.
 
-- **Why does it need to do this?**
+For the full explanation (and the real-world issues that motivated it), read the [Deep Dive](docs/Deep-Dive.md). The supported platform is **PowerShell 7.4+ (Core, net8.0)**; compatibility, versioning, and dependency details live in [DEPENDENCIES.md](DEPENDENCIES.md).
 
-  It is common for PowerShell modules to ship with DLLs that provide precompiled functionality or dependencies. A PowerShell session cannot import two different versions of the same library (DLL). If a module imports one version of a DLL and then a different module attempts to import a second, newer version of that DLL, they will typically see an error that says, "an assembly with the same name is already loaded" and the second module will not be able to function.
-
-- **Why don't modules use Application Load Context (ALC) to solve this problem?**
-
-  ALC can be very complex to implement *and* is only available in PowerShell 7. For these reasons, it is not commonly used in public modules.
-
-- **Do these issues look familiar?**
-
-### Related GitHub Issues
-
-- [Connect-MgGraph fails after Connect-ExchangeOnline](https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/3394)
-- [UUF Customer feedback: Get-EntraExtensionProperty error](https://github.com/microsoftgraph/entra-powershell/issues/1258) (Assembly with same name is already loaded)
-- [Assembly with same name is already loaded](https://github.com/microsoftgraph/entra-powershell/issues/1083)
-- [Design entra-powershell with ALC bridge pattern for a more robust assembly load handling](https://github.com/microsoftgraph/entra-powershell/issues/1242)
-- [Implement proper assembly isolation to play nice with vscode-powershell](https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/2978)
-- [Conflict with the .Net dll of the Az module PowerShell/vscode-powershell#3012](https://github.com/PowerShell/vscode-powershell/issues/3012)
-- [Unable to load Az modules - Assembly with same name is already loaded PowerShell/vscode-powershell#4727](https://github.com/PowerShell/vscode-powershell/issues/4727)
-
-### 🧑‍💻 An Example Scenario
-
-Numerous PowerShell modules include a dependency on the Microsoft Authentication Library (MSAL) for authenticating to Microsoft's online services. The latest version of the MSAL is actively maintained in **[AzureAD/microsoft-authentication-library-for-dotnet](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet)**. However, modules that depend on the MSAL libraries (such as **Microsoft.Identity.Client.dll**) all update their releases with different versions of MSAL on different schedules. This results in version conflicts that break authentication flows whenever you try to use multiple modules in one session. Examples of modules that can be affected by this include:
-
-- Az.Accounts
-- ExchangeOnlineManagement
-- Microsoft.Graph.Authentication
-- MicrosoftTeams
-- ...and many more.
-
-You could *manually* attempt to work around this by checking which version of the conflicting DLLs are used by each of your PowerShell modules and then *connect first* to whichever service module uses the newest version of the DLL. This works because of the "first one wins" rule and because the MSAL is designed to be backwards compatible. DLL Pickle handles this for you by automatically updating and releasing a new version of DLL Pickle whenever a new version of the MSAL is published. As long as you keep the DLL Pickle module up to date and run `Import-DPLibrary` before other modules, you should be able to connect to any Microsoft online service without DLL conflicts.
-
-### 🥒 Using DLL Pickle
-
-The easiest way to benefit from DLL Pickle is to import the module in your PowerShell profile before any other module or assembly is loaded. Just add the line `Import-DPLibrary` to your profile, save it, and start a new instance of PowerShell.
-
-Alternatively, if you are starting work in a new PowerShell session in which you know you will be authenticating to multiple online services, you can run `Import-DPLibrary` at the beginning of your session and then proceed with connecting to Microsoft's online services using their first party modules.
-
-### ⚙️ Platform Support
-
-- **PowerShell 7.4+ (Core, net8.0):** Fully supported target runtime.
-
-If you need diagnostic details, run:
-
-```powershell
-Import-DPLibrary -ShowLoaderExceptions -Verbose
-```
-
-For detailed cmdlet guidance, see [docs/DLLPickle/Import-DPLibrary.md](docs/DLLPickle/Import-DPLibrary.md).
-
-For deeper compatibility and dependency details, see [DEPENDENCIES.md](DEPENDENCIES.md).
-
----
-
-## 📝 Additional Information
-
-### Versioning
-
-This project follows the semantic versioning model. It also packages numerous dependencies that follow their own versioning. To maintain clarity, this project will follow SemVer standards and the following logic for version changes:
-
-#### Major Versions
-
-🏷️ **2.x.x.x** - The major version will only change if there is a breaking change in the DLL Pickle project or if an MSAL dependency is released with a new major version (potentially indicating a breaking change).
-
-#### Minor Versions
-
-🏷️ **X.1.X.X** - The minor version will change if any of the following occur:
-
-- New features are added to the project
-- New MSAL library dependencies are added to the project
-- A new version of any associated library (DLL) is automatically updated within the project
-
-#### Build Versions
-
-🏷️ **X.X.1.X** - The build version will change if any of the following occur:
-
-- Minor refactoring for performance, error handling, or logging
-- Minor fixes for typos or formatting
-
-## External Documentation
-
-All libraries tracked for pre-loading by DLL Pickle are maintained and documented by their own code owners. Please see each project accordingly:
-
-- [Microsoft.Identity.Abstractions](https://www.nuget.org/packages/Microsoft.Identity.Abstractions)
-- [Microsoft.Identity.Client](https://www.nuget.org/packages/Microsoft.Identity.Client)
-- [Microsoft.IdentityModel.Abstractions](https://www.nuget.org/packages/Microsoft.IdentityModel.Abstractions)
-- [Microsoft.IdentityModel.JsonWebTokens](https://www.nuget.org/packages/Microsoft.IdentityModel.JsonWebTokens)
-- [Microsoft.IdentityModel.Logging](https://www.nuget.org/packages/Microsoft.IdentityModel.Logging)
-- [Microsoft.IdentityModel.Tokens](https://www.nuget.org/packages/Microsoft.IdentityModel.Tokens)
-- [System.IdentityModel.Tokens.Jwt](https://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt)
-
-## Project Documentation Map
+## 📚 Documentation Map
 
 - User guide and overview: [docs/index.md](docs/index.md)
 - Deep technical explanation: [docs/Deep-Dive.md](docs/Deep-Dive.md)
+- Troubleshooting and issue reproduction: [docs/Troubleshooting.md](docs/Troubleshooting.md)
 - Full command reference: [docs/DLLPickle.md](docs/DLLPickle.md)
 - Changelog and active work: [CHANGELOG.md](CHANGELOG.md)
 - Architecture blueprint and planned enhancements: [docs/Architecture.md](docs/Architecture.md)
+- Dependency, versioning, and supply-chain policy: [DEPENDENCIES.md](DEPENDENCIES.md)
 - Contribution workflow: [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md)
-- Dependency and supply chain policy: [DEPENDENCIES.md](DEPENDENCIES.md)
 - Security vulnerability reporting: [SECURITY.md](SECURITY.md)

--- a/docs/DLLPickle.md
+++ b/docs/DLLPickle.md
@@ -46,6 +46,14 @@ Gets modules and sorts them by packaged `Microsoft.Identity.Client.dll` version.
 
 Imports DLLPickle dependency libraries.
 
+### [Import-DPBaseProfile](DLLPickle/Import-DPBaseProfile.md)
+
+Runs `Import-DPLibrary` and imports the validated base-profile modules (Exchange Online, Microsoft Teams, Microsoft Graph, and Az.Accounts) in a known-good order.
+
+### Test-DPLibraryConflict
+
+Reports known-incompatible module combinations loaded in the current session (for example the Az.Storage + ExchangeOnlineManagement OData conflict, issue #174), with the reason and the separate-process workaround. _(The per-command help page is generated during the in-progress `Microsoft.PowerShell.PlatyPS` migration.)_
+
 ## Archived Commands
 
 The following pages are retained for historical reference and migration guidance.

--- a/docs/Deep-Dive.md
+++ b/docs/Deep-Dive.md
@@ -17,6 +17,19 @@ load errors.
 DLLPickle addresses this by loading a compatible set of identity-related
 assemblies before other modules attempt their own assembly loads.
 
+## Related Issues
+
+This class of conflict is widely reported across Microsoft's first-party
+PowerShell modules:
+
+- [Connect-MgGraph fails after Connect-ExchangeOnline](https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/3394)
+- [UUF Customer feedback: Get-EntraExtensionProperty error](https://github.com/microsoftgraph/entra-powershell/issues/1258) (Assembly with same name is already loaded)
+- [Assembly with same name is already loaded](https://github.com/microsoftgraph/entra-powershell/issues/1083)
+- [Design entra-powershell with ALC bridge pattern for more robust assembly load handling](https://github.com/microsoftgraph/entra-powershell/issues/1242)
+- [Implement proper assembly isolation to play nice with vscode-powershell](https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/2978)
+- [Conflict with the .NET DLL of the Az module (vscode-powershell#3012)](https://github.com/PowerShell/vscode-powershell/issues/3012)
+- [Unable to load Az modules — Assembly with same name is already loaded (vscode-powershell#4727)](https://github.com/PowerShell/vscode-powershell/issues/4727)
+
 ## How DLLPickle Works
 
 `Import-DPLibrary` loads DLLs from the module's packaged `bin` folder that

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -120,12 +120,20 @@ add `Azure.Core.dll` to `Set-DPConfig -SkipLibraries` as a safeguard.
 
 ### Issue #174: Az.Storage and ExchangeOnlineManagement OData
 
-Az.Storage 9.6.0 imports `Microsoft.OData.Core` 7.6.4. ExchangeOnlineManagement
-3.9.2 can later request `Microsoft.OData.Core` 7.22.0 from `Get-EXO*` cmdlets.
-Preloading OData 7.22.0 from DLLPickle was tested and rejected because it
-breaks Az.Storage import with an assembly collision against its 7.6.4 copy.
+Az.Storage (9.6.1) loads `Microsoft.OData.Core` 7.6.4 at import; ExchangeOnlineManagement
+(3.9.2) needs 7.22.0 for its `Get-EXO*` cmdlets. Both load into the **default**
+`AssemblyLoadContext` and are strong-named, so the two versions cannot coexist in one
+process. A 2026-06-01 runtime probe confirmed that **both import orders fail**:
 
-The safe repro tests keep this scenario visible but do not treat OData
-preloading as a supported fix. If both modules need incompatible OData versions,
-run the Az.Storage and ExchangeOnlineManagement work in separate PowerShell
-processes so each process has its own assembly load context.
+- Az.Storage first, then `Get-EXO*` &rarr; fails (wants 7.22.0, but 7.6.4 is already loaded).
+- ExchangeOnlineManagement first, then `Import-Module Az.Storage` &rarr; fails (wants 7.6.4, but 7.22.0 is already loaded).
+
+DLLPickle cannot resolve this by preloading — preloading either version breaks the other
+module — so the OData assemblies stay on the block list. As of **2.2.0**, DLLPickle ships
+`Test-DPLibraryConflict` (and `Import-DPLibrary` surfaces the same warning automatically) to
+flag the conflict when both modules are loaded, with the reason and the workaround below.
+
+**Workaround:** run the Az.Storage and ExchangeOnlineManagement (`Get-EXO*`) work in separate
+PowerShell processes so each process has its own assembly load context. A separate runspace in
+the *same* process does **not** help (the conflict is process-wide). The safe repro tests keep
+this scenario visible but do not treat OData preloading as a supported fix.

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -129,9 +129,13 @@ process. A 2026-06-01 runtime probe confirmed that **both import orders fail**:
 - ExchangeOnlineManagement first, then `Import-Module Az.Storage` &rarr; fails (wants 7.6.4, but 7.22.0 is already loaded).
 
 DLLPickle cannot resolve this by preloading — preloading either version breaks the other
-module — so the OData assemblies stay on the block list. As of **2.2.0**, DLLPickle ships
-`Test-DPLibraryConflict` (and `Import-DPLibrary` surfaces the same warning automatically) to
-flag the conflict when both modules are loaded, with the reason and the workaround below.
+module — so the OData assemblies stay on the block list. As of **2.2.0**, run
+`Test-DPLibraryConflict` to reliably check the current session and warn (with the reason and
+the workaround below) whenever both modules are loaded. `Import-DPLibrary` also arms a
+**best-effort, advisory** watcher that surfaces the same warning if the pair becomes co-loaded
+later — but it cannot catch every case (for example, if the second module's import fails before
+any of its assemblies load, no `AssemblyLoad` event fires), so `Test-DPLibraryConflict` is the
+reliable check.
 
 **Workaround:** run the Az.Storage and ExchangeOnlineManagement (`Get-EXO*`) work in separate
 PowerShell processes so each process has its own assembly load context. A separate runspace in


### PR DESCRIPTION
## What

Two related pieces of work you asked for: **slim the README** for new-user accessibility, and **review the first-level `/docs` files** for relevancy/accuracy/currency (subdirectories `DLLPickle/`, `en-US/`, `maml/`, `superpowers/` and `requirements.txt` were intentionally excluded).

## README (171 → 81 lines)

- Merged the two duplicate **"Using"** blocks into one.
- Condensed the FAQ + "Example Scenario" into a short **"How It Works"** that links to the Deep Dive (the full story already lives in `docs/index.md` and `Deep-Dive.md`).
- **Completed the command list** — it previously showed only 7 of 9 exported commands (missing `Import-DPBaseProfile` and `Test-DPLibraryConflict`); now all 9, grouped Primary vs Inspection helpers.
- Added `Troubleshooting.md` to the documentation map.

**Moved into `/docs`:**
- **Versioning** → `DEPENDENCIES.md`. ⚠️ Reconciled with reality: the old text described **4 segments** (`2.x.x.x`) and an "MSAL update → minor / refactor → build" rule, but releases are **3-segment SemVer driven by Conventional Commits** (feat→minor, fix→patch) and publish only on bundle changes. If your *intended* policy differs from what the automation does, say so and I'll adjust.
- Tracked-library **NuGet doc links** → `DEPENDENCIES.md`.
- **Related GitHub Issues** list → `docs/Deep-Dive.md` as motivating background.

## `/docs` review findings + fixes

| File | Verdict | Action |
|---|---|---|
| `index.md` | Current | None (canonical story; README now defers to it) |
| `Deep-Dive.md` | Current | Received the Related Issues list |
| `Architecture.md` | Current | None (you flagged restructuring as future work) |
| `Troubleshooting.md` | ⚠️ #174 stale | Refreshed to the runtime-confirmed *both-orders-fail* conclusion, referenced `Test-DPLibraryConflict` (2.2.0), corrected Az.Storage `9.6.0` → `9.6.1` |
| `DLLPickle.md` | ⚠️ Inaccurate | Added the 2 missing commands (`Import-DPBaseProfile` linked; `Test-DPLibraryConflict` unlinked — its per-command page is generated by the in-progress PlatyPS migration) |

**Note:** `DLLPickle.md` is PlatyPS-generated; its stale front-matter `Help Version`/`ms.date` will refresh when the `Microsoft.PowerShell.PlatyPS` migration regenerates it (tracked in CHANGELOG `[Unreleased]`).

Docs-only — no `src/`/bundle change, so this does not trigger a release.
