### PR TITLE
fix(policy): adjudicate issue 239 conflict drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The upstream-compatibility required check is now an always-reported aggregate. Policy, dependency, and fingerprint-generator changes run a live freshness check, while deterministic guardrail changes can be repaired without accepting a stale baseline.
 - Scheduled conflict-surface monitoring now runs daily, publishes compact JSON evidence and a job summary, and reports the exact monitored module versions.
 - Dependabot auto-approval now rejects any PR containing files outside the NuGet project/lock-file allow-list.
+- Upstream inventory capture now resolves every monitored module version before downloading any module, so the resulting inventory is an atomic version snapshot.
+- The issue #239 conflict baseline now records the full version- and contributor-aware surface. Adjudication against the latest monitored modules confirmed that classifications and the bundled set are unchanged.
 
 ### Fixed
 

--- a/build/dependency-policy.json
+++ b/build/dependency-policy.json
@@ -71,15 +71,220 @@
     ]
   },
   "baseline": {
-    "capturedOn": "2026-05-31",
+    "capturedOn": "2026-06-20",
     "moduleVersions": {
-      "Az.Accounts": "5.4.0",
-      "Microsoft.Graph.Authentication": "2.37.0",
-      "ExchangeOnlineManagement": "3.9.2",
+      "Az.Accounts": "5.5.0",
+      "Microsoft.Graph.Authentication": "2.38.0",
+      "ExchangeOnlineManagement": "3.10.0",
       "MicrosoftTeams": "7.8.0",
-      "Az.Storage": "9.6.1"
+      "Az.Storage": "9.7.0"
     },
-    "conflictSurfaceFingerprint": "b04622cba725f5cb9c1cee4bb928879564ff6e700b574f92f744673151b90798"
+    "conflictSurfaceFingerprint": "af1f1358ba4bcd4793a2b460c5b7fc46c2661df981244317c00a695d08c06250",
+    "conflictSurface": [
+      {
+        "name": "Azure.Core",
+        "versions": [
+          "1.50.0.0",
+          "1.51.1.0"
+        ],
+        "shippedBy": [
+          "Az.Accounts",
+          "ExchangeOnlineManagement",
+          "Microsoft.Graph.Authentication"
+        ]
+      },
+      {
+        "name": "Azure.Identity",
+        "versions": [
+          "1.17.2.0",
+          "1.18.0.0"
+        ],
+        "shippedBy": [
+          "Az.Accounts",
+          "Microsoft.Graph.Authentication"
+        ]
+      },
+      {
+        "name": "Azure.Identity.Broker",
+        "versions": [
+          "1.1.0.0",
+          "1.4.0.0"
+        ],
+        "shippedBy": [
+          "Az.Accounts",
+          "Microsoft.Graph.Authentication"
+        ]
+      },
+      {
+        "name": "Microsoft.Identity.Client",
+        "versions": [
+          "4.81.0.0",
+          "4.82.1.0",
+          "4.83.1.0"
+        ],
+        "shippedBy": [
+          "Az.Accounts",
+          "ExchangeOnlineManagement",
+          "Microsoft.Graph.Authentication",
+          "MicrosoftTeams"
+        ]
+      },
+      {
+        "name": "Microsoft.Identity.Client.Broker",
+        "versions": [
+          "4.78.0.0",
+          "4.81.0.0",
+          "4.83.1.0"
+        ],
+        "shippedBy": [
+          "Az.Accounts",
+          "ExchangeOnlineManagement",
+          "Microsoft.Graph.Authentication",
+          "MicrosoftTeams"
+        ]
+      },
+      {
+        "name": "Microsoft.Identity.Client.Extensions.Msal",
+        "versions": [
+          "4.78.0.0",
+          "4.81.0.0",
+          "4.83.1.0"
+        ],
+        "shippedBy": [
+          "Az.Accounts",
+          "Microsoft.Graph.Authentication",
+          "MicrosoftTeams"
+        ]
+      },
+      {
+        "name": "Microsoft.Identity.Client.NativeInterop",
+        "versions": [
+          "0.19.4.0",
+          "0.20.2.0"
+        ],
+        "shippedBy": [
+          "Az.Accounts",
+          "ExchangeOnlineManagement",
+          "Microsoft.Graph.Authentication",
+          "MicrosoftTeams"
+        ]
+      },
+      {
+        "name": "Microsoft.IdentityModel.Abstractions",
+        "versions": [
+          "8.14.0.0",
+          "8.17.0.0",
+          "8.18.0.0"
+        ],
+        "shippedBy": [
+          "Az.Accounts",
+          "ExchangeOnlineManagement",
+          "Microsoft.Graph.Authentication",
+          "MicrosoftTeams"
+        ]
+      },
+      {
+        "name": "Microsoft.IdentityModel.JsonWebTokens",
+        "versions": [
+          "8.17.0.0",
+          "8.3.0.0",
+          "8.9.0.0"
+        ],
+        "shippedBy": [
+          "ExchangeOnlineManagement",
+          "MicrosoftTeams"
+        ]
+      },
+      {
+        "name": "Microsoft.IdentityModel.Logging",
+        "versions": [
+          "8.17.0.0",
+          "8.3.0.0",
+          "8.9.0.0"
+        ],
+        "shippedBy": [
+          "ExchangeOnlineManagement",
+          "MicrosoftTeams"
+        ]
+      },
+      {
+        "name": "Microsoft.IdentityModel.Tokens",
+        "versions": [
+          "8.17.0.0",
+          "8.3.0.0",
+          "8.9.0.0"
+        ],
+        "shippedBy": [
+          "ExchangeOnlineManagement",
+          "MicrosoftTeams"
+        ]
+      },
+      {
+        "name": "Microsoft.OData.Core",
+        "versions": [
+          "7.22.0.0",
+          "7.6.4.0"
+        ],
+        "shippedBy": [
+          "Az.Storage",
+          "ExchangeOnlineManagement"
+        ]
+      },
+      {
+        "name": "Microsoft.OData.Edm",
+        "versions": [
+          "7.22.0.0",
+          "7.6.4.0"
+        ],
+        "shippedBy": [
+          "Az.Storage",
+          "ExchangeOnlineManagement"
+        ]
+      },
+      {
+        "name": "Microsoft.Spatial",
+        "versions": [
+          "7.22.0.0",
+          "7.6.4.0"
+        ],
+        "shippedBy": [
+          "Az.Storage",
+          "ExchangeOnlineManagement"
+        ]
+      },
+      {
+        "name": "System.ClientModel",
+        "versions": [
+          "1.8.0.0",
+          "1.9.0.0"
+        ],
+        "shippedBy": [
+          "Az.Accounts",
+          "Microsoft.Graph.Authentication"
+        ]
+      },
+      {
+        "name": "System.IdentityModel.Tokens.Jwt",
+        "versions": [
+          "8.17.0.0",
+          "8.3.0.0"
+        ],
+        "shippedBy": [
+          "ExchangeOnlineManagement",
+          "MicrosoftTeams"
+        ]
+      }
+    ],
+    "validation": {
+      "issue": 239,
+      "result": "classifications-unchanged",
+      "validatedOn": "2026-06-20",
+      "evidence": [
+        "Atomic latest-module inventory and structured matrix comparison found version-only drift: no new, removed, contributor, or ALC-ownership changes.",
+        "Strict runtime ALC snapshots covered both configured import orders, with and without DLLPickle preloading.",
+        "Issue reproduction and composition validation confirmed the current preload and block classifications."
+      ]
+    }
   },
   "preload": [
     {

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -108,6 +108,10 @@ When changing the preload contract, follow this loop:
 6. **Validate** (non-auth gates always; auth tier for any bundled-set change).
 7. **Update this blueprint** if the contract or invariants changed.
 
+The baseline is a reproducible snapshot, not just a hash: `baseline.conflictSurface` stores every diverging assembly's `name`, sorted `versions`, and sorted `shippedBy` contributors alongside the module versions and fingerprint. Baseline refreshes must resolve all monitored versions before downloading any module, then prove that the stored rows recompute to the recorded fingerprint. Version-only moves are material drift and require adjudication; they do not pass silently.
+
+Issue #239 was adjudicated on 2026-06-20 against Microsoft.Graph.Authentication 2.38.0, ExchangeOnlineManagement 3.10.0, Az.Storage 9.7.0, Az.Accounts 5.5.0, and MicrosoftTeams 7.8.0. The 16 conflict names and their contributors were unchanged. Strict probes of both configured import orders, with and without DLLPickle preloading, confirmed the existing preload/block classifications, so only the structured policy baseline changed; the bundled set and public module behavior did not.
+
 **Hard gates (non-negotiable):**
 
 - A design must be approved before implementation (see the spec/plan workflow under `docs/superpowers/`).

--- a/tests/Unit/DependencyAutomation.Tests.ps1
+++ b/tests/Unit/DependencyAutomation.Tests.ps1
@@ -6,6 +6,49 @@ BeforeAll {
 }
 
 Describe 'Dependency automation tooling' -Tag 'Unit' {
+    It 'resolves every monitored module version before downloading any module' {
+        $Assembly = [System.String].Assembly
+        $AssemblyName = $Assembly.GetName().Name
+        $ModuleCachePath = Join-Path -Path $TestDrive -ChildPath 'atomic-modules'
+        $PolicyPath = Join-Path -Path $TestDrive -ChildPath 'atomic-policy.json'
+        @{
+            monitoredModules = @(
+                @{ name = 'Synthetic.One'; repository = 'PSGallery'; purpose = 'First synthetic module.' }
+                @{ name = 'Synthetic.Two'; repository = 'PSGallery'; purpose = 'Second synthetic module.' }
+            )
+            trackedAssemblies = @($AssemblyName)
+        } | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $PolicyPath -Encoding UTF8
+
+        $InventoryTestStateKey = 'DLLPickle.DependencyAutomation.InventoryTestState'
+        $InventoryTestState = [PSCustomObject]@{
+            Events           = [System.Collections.Generic.List[string]]::new()
+            AssemblyLocation = $Assembly.Location
+            AssemblyName     = $AssemblyName
+        }
+        [System.AppDomain]::CurrentDomain.SetData($InventoryTestStateKey, $InventoryTestState)
+        Mock Find-Module {
+            $State = [System.AppDomain]::CurrentDomain.GetData('DLLPickle.DependencyAutomation.InventoryTestState')
+            $State.Events.Add("find:$Name")
+            [PSCustomObject]@{
+                Name = $Name
+                Version = if ($Name -eq 'Synthetic.One') { [version]'1.2.3' } else { [version]'4.5.6' }
+            }
+        }
+        Mock Save-Module {
+            $State = [System.AppDomain]::CurrentDomain.GetData('DLLPickle.DependencyAutomation.InventoryTestState')
+            $State.Events.Add("save:$Name")
+            $ModuleRoot = Join-Path -Path $Path -ChildPath ([System.IO.Path]::Combine($Name, [string]$RequiredVersion))
+            $null = New-Item -Path $ModuleRoot -ItemType Directory -Force
+            Copy-Item -LiteralPath $State.AssemblyLocation -Destination (Join-Path $ModuleRoot "$($State.AssemblyName).dll") -Force
+        }
+
+        $null = & $script:InventoryScriptPath -PolicyPath $PolicyPath -ModuleCachePath $ModuleCachePath -OutputPath (Join-Path $TestDrive 'atomic-inventory.json')
+
+        $InventoryEvents = @($InventoryTestState.Events)
+        [System.AppDomain]::CurrentDomain.SetData($InventoryTestStateKey, $null)
+        $InventoryEvents | Should -Be @('find:Synthetic.One', 'find:Synthetic.Two', 'save:Synthetic.One', 'save:Synthetic.Two')
+    }
+
     It 'inventories tracked assemblies from an existing module cache' {
         $Assembly = [System.String].Assembly
         $AssemblyName = $Assembly.GetName().Name

--- a/tests/Unit/DependencyPolicy.Tests.ps1
+++ b/tests/Unit/DependencyPolicy.Tests.ps1
@@ -1,0 +1,50 @@
+BeforeAll {
+    $ProjectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+    $script:Policy = Get-Content -LiteralPath (Join-Path $ProjectRoot 'build\dependency-policy.json') -Raw | ConvertFrom-Json
+}
+
+Describe 'Dependency policy baseline' -Tag 'Unit' {
+    It 'records the complete structured conflict surface' {
+        @($script:Policy.baseline.conflictSurface) | Should -HaveCount 16
+
+        foreach ($Row in $script:Policy.baseline.conflictSurface) {
+            $Row.name | Should -Not -BeNullOrEmpty
+            @($Row.versions) | Should -Not -BeNullOrEmpty
+            @($Row.shippedBy) | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    It 'has a fingerprint that matches the structured conflict surface' {
+        $SurfaceRows = @(
+            $script:Policy.baseline.conflictSurface |
+                Sort-Object name |
+                ForEach-Object {
+                    '{0}={1};by={2}' -f $_.name, (@($_.versions | Sort-Object) -join ','), (@($_.shippedBy | Sort-Object) -join ',')
+                }
+        )
+        $FingerprintBytes = [System.Text.Encoding]::UTF8.GetBytes(($SurfaceRows -join '|'))
+        $Fingerprint = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::HashData($FingerprintBytes)).Replace('-', '').ToLowerInvariant()
+
+        $script:Policy.baseline.conflictSurfaceFingerprint | Should -BeExactly $Fingerprint
+    }
+
+    It 'classifies every conflict row exactly once' {
+        $ConflictNames = @($script:Policy.baseline.conflictSurface).name
+        $ClassifiedNames = @(
+            @($script:Policy.preload).assemblyName
+            @($script:Policy.blockedPreloadAssemblies).assemblyName
+        )
+
+        $ConflictNames | Should -HaveCount 16
+        foreach ($Name in $ConflictNames) {
+            @($ClassifiedNames | Where-Object { $_ -eq $Name }) | Should -HaveCount 1
+        }
+    }
+
+    It 'records the issue 239 adjudication evidence' {
+        $script:Policy.baseline.validation.issue | Should -Be 239
+        $script:Policy.baseline.validation.result | Should -BeExactly 'classifications-unchanged'
+        $script:Policy.baseline.validation.validatedOn | Should -BeExactly '2026-06-20'
+        @($script:Policy.baseline.validation.evidence) | Should -Not -BeNullOrEmpty
+    }
+}

--- a/tools/Get-DLLPickleUpstreamInventory.ps1
+++ b/tools/Get-DLLPickleUpstreamInventory.ps1
@@ -154,6 +154,18 @@ if ($PolicyModules.Count -eq 0) {
 }
 
 $null = New-Item -Path $ModuleCachePath -ItemType Directory -Force
+$ResolvedModuleVersions = @{}
+if (-not $SkipDownload.IsPresent) {
+    # Resolve the complete upstream snapshot before downloading anything. This prevents a module
+    # release published midway through the run from producing an internally mixed baseline.
+    foreach ($PolicyModule in $PolicyModules) {
+        $Name = [string]$PolicyModule.name
+        $Repository = if ($PolicyModule.repository) { [string]$PolicyModule.repository } else { 'PSGallery' }
+        $GalleryModule = Find-Module -Name $Name -Repository $Repository -ErrorAction Stop
+        $ResolvedModuleVersions[$Name] = $GalleryModule.Version
+    }
+}
+
 $ModuleResults = foreach ($PolicyModule in $PolicyModules) {
     $Name = [string]$PolicyModule.name
     $Repository = if ($PolicyModule.repository) { [string]$PolicyModule.repository } else { 'PSGallery' }
@@ -164,10 +176,9 @@ $ModuleResults = foreach ($PolicyModule in $PolicyModules) {
             Remove-Item -LiteralPath $ModuleRoot -Recurse -Force
         }
 
-        $GalleryModule = Find-Module -Name $Name -Repository $Repository -ErrorAction Stop
         $SaveModuleParameters = @{
             Name            = $Name
-            RequiredVersion = $GalleryModule.Version
+            RequiredVersion = $ResolvedModuleVersions[$Name]
             Repository      = $Repository
             Path            = $ModuleCachePath
             Force           = $true


### PR DESCRIPTION
## Summary

- resolves all monitored module versions before any download so inventory capture is atomic
- records the current 16-row version/contributor conflict surface and fingerprint af1f1358ba4bcd4793a2b460c5b7fc46c2661df981244317c00a695d08c06250
- documents the issue #239 adjudication and adds baseline fingerprint/classification consistency tests

PR #243 supplied the guardrails required before this baseline refresh.

## Adjudication

The latest monitored versions are Graph Authentication 2.38.0, ExchangeOnlineManagement 3.10.0, Az.Storage 9.7.0, Az.Accounts 5.5.0, and MicrosoftTeams 7.8.0.

Structured comparison found version-only drift: no new or removed conflicts, contributor changes, or ALC-ownership changes. Strict probes covered both configured import orders with and without DLLPickle preloading. The existing preload/block classifications remain valid.

This is policy/tooling/documentation only. It does not change KnownConflicts.json, module source, the csproj, the lock file, or the published bundle.

## Validation

- Invoke-Build -File ./build/DLLPickle.Build.ps1 -Task Analyze,Test (153 passed)
- Invoke-Build -File ./build/DLLPickle.Build.ps1 -Task IssueReproTest (10 passed, 3 LiveRepro tests intentionally excluded)
- fresh atomic upstream inventory matched every recorded module version, all 16 rows, and the recorded fingerprint

Closes #239