### PR TITLE
fix(module): remove unsafe assembly event callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependabot auto-approval now rejects any PR containing files outside the NuGet project/lock-file allow-list.
 - Upstream inventory capture now resolves every monitored module version before downloading any module, so the resulting inventory is an atomic version snapshot.
 - The issue #239 conflict baseline now records the full version- and contributor-aware surface. Adjudication against the latest monitored modules confirmed that classifications and the bundled set are unchanged.
+- Automatic future-load conflict watching has been removed. `Import-DPLibrary` still warns once for known conflicts that are already loaded; run `Test-DPLibraryConflict` after later module imports for the reliable on-demand check.
 
 ### Fixed
 
 - `Compare-DLLPickleConflictMatrix.ps1` now treats version, contributor, removed-conflict, and ALC changes consistently with the version-aware fingerprint gate.
 - Runtime ALC snapshots support strict adjudication mode, where module-import and probe-command failures are fatal instead of producing partial evidence.
+- `Import-DPLibrary` no longer registers PowerShell script blocks as CLR `AssemblyResolve` or `AssemblyLoad` event handlers. Those events can run on threads without a PowerShell runspace and terminate the process with `PSInvalidOperationException` (#242).
+- Dependency loading now relies on the supported-runtime dependency graph, deterministic fallback ordering, and retries. Synthetic transitive-dependency coverage confirmed that the legacy Windows PowerShell 5.1 resolver is not required on PowerShell 7.4+ / .NET 8.
 
 ## [2.2.0] - 2026-06-02
 

--- a/docs/DLLPickle/Import-DPLibrary.md
+++ b/docs/DLLPickle/Import-DPLibrary.md
@@ -33,12 +33,10 @@ DLLs are loaded from:
 The latest versions of all dependencies are automatically imported, providing
 backwards compatibility and avoiding version conflicts.
 
-Import-DPLibrary uses dependency-graph-based load ordering, a local assembly
-resolution fallback, and retry logic to reduce transient assembly load failures
-This approach derives dependency-first ordering from local assembly metadata,
-appends unresolved graph nodes deterministically in alphabetical order, and
-resolves same-name assemblies from the module's local bin folder when .NET
-runtime probing does not resolve them on the first pass.
+Import-DPLibrary uses dependency-graph-based load ordering and retry logic to
+reduce transient assembly load failures. This approach derives dependency-first
+ordering from local assembly metadata and appends unresolved graph nodes
+deterministically in alphabetical order.
 
 If an assembly still fails due to unresolved transitive dependencies or platform limitations,
 Import-DPLibrary retries the failed assembly set and returns detailed diagnostics for

--- a/docs/DLLPickle/about_DLLPickle.help.md
+++ b/docs/DLLPickle/about_DLLPickle.help.md
@@ -46,8 +46,7 @@ compatible dependency set from the module's `bin` folder:
 - `bin/net8.0` on PowerShell 7.4+
 
 The loader applies dependency-aware ordering, deterministic fallback ordering,
-and scoped local resolution fallback to improve reliability during assembly
-probing.
+and retries to improve reliability during assembly probing.
 
 ## Optional Subtopics
 

--- a/docs/Deep-Dive.md
+++ b/docs/Deep-Dive.md
@@ -42,7 +42,6 @@ To improve reliability, the loader:
 1. Builds a dependency graph from local assembly metadata.
 1. Applies dependency-first ordering where possible.
 1. Appends unresolved nodes in deterministic alphabetical order.
-1. Registers a scoped local assembly resolution fallback.
 1. Adds packaged native runtime directories for the current process RID to
    `PATH` so broker/MSAL native dependencies can be found without loading native
    DLLs as managed assemblies.
@@ -188,7 +187,8 @@ exclusion for environment-specific troubleshooting.
 
 This is an upstream incompatibility between the two modules; **DLLPickle cannot fix it by preloading**
 (preloading either version breaks the other module), which is why the OData assemblies are
-classified `block`. DLLPickle warns when it detects both modules loaded (see `Test-DPLibraryConflict`).
+classified `block`. `Import-DPLibrary` warns if it finds both modules already loaded; run
+`Test-DPLibraryConflict` after later imports to check the session again.
 
 **Workaround:** use the two modules in **separate PowerShell processes** — for example, run `Get-EXO*`
 work in one `pwsh` (or a `Start-Job` background job) and `Az.Storage` work in another. A separate

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -131,11 +131,9 @@ process. A 2026-06-01 runtime probe confirmed that **both import orders fail**:
 DLLPickle cannot resolve this by preloading — preloading either version breaks the other
 module — so the OData assemblies stay on the block list. As of **2.2.0**, run
 `Test-DPLibraryConflict` to reliably check the current session and warn (with the reason and
-the workaround below) whenever both modules are loaded. `Import-DPLibrary` also arms a
-**best-effort, advisory** watcher that surfaces the same warning if the pair becomes co-loaded
-later — but it cannot catch every case (for example, if the second module's import fails before
-any of its assemblies load, no `AssemblyLoad` event fires), so `Test-DPLibraryConflict` is the
-reliable check.
+the workaround below) whenever both modules are loaded. `Import-DPLibrary` warns if the pair is
+already loaded when preloading finishes. It does not watch later assembly loads; run
+`Test-DPLibraryConflict` after subsequent module imports when you need to recheck the session.
 
 **Workaround:** run the Az.Storage and ExchangeOnlineManagement (`Get-EXO*`) work in separate
 PowerShell processes so each process has its own assembly load context. A separate runspace in

--- a/docs/superpowers/plans/2026-06-20-issue242-background-event-handlers.md
+++ b/docs/superpowers/plans/2026-06-20-issue242-background-event-handlers.md
@@ -1,0 +1,223 @@
+# Issue 242 Background Event Handlers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate process-terminating PowerShell CLR event delegates while preserving supported-runtime DLL loading, adding a compiled resolver only if deletion evidence requires it.
+
+**Architecture:** Delete the advisory `AssemblyLoad` watcher and experimentally remove the legacy `AssemblyResolve` fallback. Deterministic Pester tests verify source safety, child-process survival, and synthetic transitive dependency loading; a narrowly scoped precompiled resolver is conditional on an observed loading failure.
+
+**Tech Stack:** PowerShell 7.4+, .NET 8, Pester 5.7, Invoke-Build.
+
+## Global Constraints
+
+- Support PowerShell 7.4+ and `net8.0` only.
+- Do not execute PowerShell script blocks from CLR assembly-event publisher threads.
+- Do not use runtime `Add-Type` as the production fix.
+- Do not add network-dependent tests.
+- Run fatal-crash regressions only in child processes with bounded timeouts.
+- Preserve `Import-DPLibrary` result objects and the public `Test-DPLibraryConflict` command.
+
+---
+
+### Task 1: Add deletion-experiment regression tests
+
+**Files:**
+- Create: `tests/Unit/AssemblyEventSafety.Tests.ps1`
+- Modify: `tests/Unit/Import-DPLibrary.Tests.ps1`
+
+**Interfaces:**
+- Consumes: source files under `src/DLLPickle` and the existing `Import-DPLibrary` function.
+- Produces: source guardrails and supported-runtime dependency-loading evidence.
+
+- [ ] **Step 1: Add a source guard that rejects direct assembly-event script-block delegates**
+
+```powershell
+Describe 'Assembly event safety' -Tag 'Unit' {
+    It 'does not register PowerShell script blocks as CLR assembly event delegates' {
+        $Source = Get-ChildItem -LiteralPath (Join-Path $RepoRoot 'src\DLLPickle') -Filter '*.ps1' -Recurse |
+            Get-Content -Raw
+
+        ($Source -join [Environment]::NewLine) | Should -Not -Match '\[System\.(AssemblyLoadEventHandler|ResolveEventHandler)\]\s*\{'
+    }
+}
+```
+
+- [ ] **Step 2: Run the source guard and verify RED**
+
+Run: `Invoke-Pester -Path ./tests/Unit/AssemblyEventSafety.Tests.ps1 -Output Detailed`
+
+Expected: FAIL because both direct script-block delegate casts still exist.
+
+- [ ] **Step 3: Add a deterministic synthetic dependency test to `Import-DPLibrary.Tests.ps1`**
+
+Compile `Synthetic.Dependency.dll` and `Synthetic.Consumer.dll` into the test TFM directory. The consumer exposes a method returning a value from the dependency. Mock configuration and file discovery, invoke `Import-DPLibrary`, invoke the consumer method, and assert both assemblies report `Imported` or `Already Loaded` without relying on an `AssemblyResolve` callback.
+
+- [ ] **Step 4: Run the synthetic dependency test before deletion**
+
+Run: `Invoke-Pester -Path ./tests/Unit/Import-DPLibrary.Tests.ps1 -Output Detailed`
+
+Expected: PASS, establishing the test fixture and current loading baseline.
+
+- [ ] **Step 5: Commit the test-first state**
+
+```powershell
+git add tests/Unit/AssemblyEventSafety.Tests.ps1 tests/Unit/Import-DPLibrary.Tests.ps1
+git commit -m "test(module): reproduce unsafe assembly event delegates"
+```
+
+### Task 2: Delete unsafe callbacks and preserve immediate conflict checks
+
+**Files:**
+- Modify: `src/DLLPickle/Public/Import-DPLibrary.ps1`
+- Modify: `src/DLLPickle/Private/Invoke-DPConflictCheck.ps1`
+- Modify: `tests/Unit/KnownConflicts.Tests.ps1`
+
+**Interfaces:**
+- Consumes: `Get-DPKnownConflict`, `Format-DPConflictWarning`, dependency ordering, and retry loading.
+- Produces: `Invoke-DPConflictCheck` that warns once only for conflicts already loaded; `Import-DPLibrary` with no assembly-event delegate.
+
+- [ ] **Step 1: Remove the resolver map, `ResolveEventHandler`, subscription, and unsubscription**
+
+Retain `ConvertTo-DPPublicKeyTokenText` and `Test-DPAssemblyIdentityCompatible` because the main load loop uses them to classify already-loaded compatible assemblies.
+
+- [ ] **Step 2: Reduce `Invoke-DPConflictCheck` to immediate detection**
+
+For each known conflict, compare its module names with `Get-Module`; warn and add the conflict ID to `$script:DPConflictHandled` only when every module is currently loaded. Do not query installed modules or register future callbacks.
+
+- [ ] **Step 3: Add focused immediate-check tests**
+
+Add tests that dot-source `Invoke-DPConflictCheck.ps1`, use synthetic known-conflict JSON with always-loaded PowerShell modules, and assert one warning across two invocations plus no event subscriber growth.
+
+- [ ] **Step 4: Verify GREEN and apply the resolver decision gate**
+
+Run:
+
+```powershell
+Invoke-Pester -Path ./tests/Unit/AssemblyEventSafety.Tests.ps1,./tests/Unit/Import-DPLibrary.Tests.ps1,./tests/Unit/KnownConflicts.Tests.ps1 -Output Detailed
+```
+
+Decision:
+
+- If the synthetic consumer executes and all focused tests pass, do not add C#.
+- If the consumer fails specifically because `Synthetic.Dependency` cannot resolve despite dependency ordering and retries, execute Task 3.
+- For any unrelated failure, diagnose it rather than adding the resolver.
+
+- [ ] **Step 5: Commit the deletion implementation**
+
+```powershell
+git add src/DLLPickle/Public/Import-DPLibrary.ps1 src/DLLPickle/Private/Invoke-DPConflictCheck.ps1 tests/Unit/KnownConflicts.Tests.ps1
+git commit -m "fix(module): remove unsafe assembly event callbacks"
+```
+
+### Task 3: Conditional compiled resolver fallback
+
+**Condition:** Execute only if Task 2's synthetic dependency test proves that the supported runtime requires explicit resolution.
+
+**Files:**
+- Create: `src/DLLPickle.Build/AssemblyResolverScope.cs`
+- Modify: `src/DLLPickle.Build/DLLPickle.csproj`
+- Modify: `build/DLLPickle.Build.ps1`
+- Modify: `src/DLLPickle/Public/Import-DPLibrary.ps1`
+- Create: `tests/Unit/AssemblyResolverScope.Tests.ps1`
+
+**Interfaces:**
+- Produces: `DLLPickle.Runtime.AssemblyResolverScope : IDisposable`, constructed with `IReadOnlyDictionary<string,string>` and a canonical allowed root.
+- Behavior: subscribes to `AppDomain.AssemblyResolve`; returns only exact-identity assemblies under the allowed root; returns `null` otherwise; idempotently unsubscribes from `Dispose()`.
+
+- [ ] **Step 1: Add failing resolver contract tests**
+
+Cover exact identity, unknown name, incompatible version, out-of-root path, background-thread invocation, and double disposal.
+
+- [ ] **Step 2: Verify RED because the runtime helper does not exist**
+
+Run: `Invoke-Pester -Path ./tests/Unit/AssemblyResolverScope.Tests.ps1 -Output Detailed`
+
+- [ ] **Step 3: Implement the minimal resolver and package it as `DLLPickle.Runtime.dll`**
+
+Use immutable constructor state, `Path.GetFullPath`, directory-boundary validation, exact identity comparison, and a `try/catch` returning `null`. Never hold a lock while calling `Assembly.LoadFrom`.
+
+- [ ] **Step 4: Scope the resolver with PowerShell `try/finally`**
+
+Create it immediately before the load loop and call `Dispose()` in `finally`. Build its map only from DLLs already enumerated under the TFM directory.
+
+- [ ] **Step 5: Verify the resolver tests and deletion guard**
+
+Run: `Invoke-Pester -Path ./tests/Unit/AssemblyResolverScope.Tests.ps1,./tests/Unit/AssemblyEventSafety.Tests.ps1,./tests/Unit/Import-DPLibrary.Tests.ps1 -Output Detailed`
+
+- [ ] **Step 6: Commit the evidence-required fallback**
+
+```powershell
+git add src/DLLPickle.Build/AssemblyResolverScope.cs src/DLLPickle.Build/DLLPickle.csproj build/DLLPickle.Build.ps1 src/DLLPickle/Public/Import-DPLibrary.ps1 tests/Unit/AssemblyResolverScope.Tests.ps1
+git commit -m "fix(module): add thread-safe assembly resolver scope"
+```
+
+### Task 4: Add child-process regression and update documentation
+
+**Files:**
+- Create: `tests/Integration/DLLPickle.Issue242.BackgroundEvents.Tests.ps1`
+- Modify: `docs/Troubleshooting.md`
+- Modify: `docs/Deep-Dive.md`
+- Modify: `docs/DLLPickle/Import-DPLibrary.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: built module at `module/DLLPickle/DLLPickle.psd1` and `Invoke-DLLPickleScenario`.
+- Produces: isolated process regression evidence and accurate user-facing behavior.
+
+- [ ] **Step 1: Add the child-process regression**
+
+Import the built module, call `Import-DPLibrary -SuppressLogo`, cause a background-thread dynamic assembly load, and assert process exit code zero with no `PSInvalidOperationException`. Use a 30-second timeout.
+
+- [ ] **Step 2: Run the regression against the fixed source**
+
+Run: `Invoke-Build -File ./build/DLLPickle.Build.ps1 -Task IssueReproTest`
+
+Expected: PASS.
+
+- [ ] **Step 3: Update documentation**
+
+Remove claims that DLLPickle automatically warns when future module loads complete a conflict. State that `Import-DPLibrary` warns for conflicts already loaded and `Test-DPLibraryConflict` is the reliable on-demand check. Record issue #242 under the unreleased changelog.
+
+- [ ] **Step 4: Commit regression and documentation**
+
+```powershell
+git add tests/Integration/DLLPickle.Issue242.BackgroundEvents.Tests.ps1 docs/Troubleshooting.md docs/Deep-Dive.md docs/DLLPickle/Import-DPLibrary.md CHANGELOG.md
+git commit -m "test(module): cover issue 242 background assembly events"
+```
+
+### Task 5: Full verification and review
+
+**Files:**
+- Verify all changed files.
+
+**Interfaces:**
+- Produces: evidence that issue #242 is resolved without a maintenance-heavy bridge.
+
+- [ ] **Step 1: Run analyzer and unit tests**
+
+Run: `Invoke-Build -File ./build/DLLPickle.Build.ps1 -Task Analyze,Test`
+
+Expected: zero errors and zero failed tests.
+
+- [ ] **Step 2: Run issue reproductions**
+
+Run: `Invoke-Build -File ./build/DLLPickle.Build.ps1 -Task IssueReproTest`
+
+Expected: zero failed integration tests.
+
+- [ ] **Step 3: Run the complete build**
+
+Run: `Invoke-Build -File ./build/DLLPickle.Build.ps1`
+
+Expected: build exit code zero.
+
+- [ ] **Step 4: Review repository state**
+
+```powershell
+git status --short
+git diff origin/main...HEAD --check
+git diff origin/main...HEAD --stat
+```
+
+Expected: only issue-242 files changed, no whitespace errors, and no uncommitted generated artifacts.
+

--- a/docs/superpowers/specs/2026-06-20-issue242-background-event-handler-design.md
+++ b/docs/superpowers/specs/2026-06-20-issue242-background-event-handler-design.md
@@ -1,0 +1,49 @@
+# Issue 242 Background Event Handler Design
+
+## Goal
+
+Prevent `Import-DPLibrary` from installing PowerShell script blocks as CLR event delegates that may execute on threads without a PowerShell runspace.
+
+## Supported Baseline
+
+- PowerShell 7.4 or later.
+- The `net8.0` dependency bundle.
+- Windows, Linux, and macOS.
+- No Windows PowerShell 5.1 or .NET Framework compatibility work.
+
+## Root Cause
+
+`Import-DPLibrary` casts a script block to `System.ResolveEventHandler`, and `Invoke-DPConflictCheck` casts another script block to `System.AssemblyLoadEventHandler`. CLR publishers can invoke both delegates on arbitrary threads. PowerShell attempts to obtain a runspace before entering either script block body, so the functions' internal `try` blocks cannot catch the resulting `PSInvalidOperationException`.
+
+## Design
+
+Start with deletion, because both callbacks may be legacy or advisory under the current baseline:
+
+1. Remove the one-shot `AssemblyLoad` watcher. Keep immediate conflict detection and the public `Test-DPLibraryConflict` command. The automatic future warning is advisory and does not justify a cross-thread event bridge.
+2. Remove the temporary `AssemblyResolve` handler and retain dependency-graph ordering, same-directory .NET loading, and retry behavior.
+3. Prove the deletion with deterministic synthetic dependency and child-process regression tests.
+4. Add a compiled resolver only if the synthetic dependency test demonstrates that supported-runtime loading fails without the handler.
+
+The fallback resolver, if required, must be a precompiled `net8.0` type. It must use an immutable map of canonical paths under the module's `bin/net8.0` directory, match assembly name/version/culture/public-key-token exactly, return `null` for every unrelated request, and unregister through `IDisposable`. Runtime `Add-Type` and captured PowerShell runspaces are prohibited.
+
+## Behavior Changes
+
+- `Import-DPLibrary` still warns immediately when a known conflicting module pair is already loaded.
+- DLLPickle no longer attempts to warn later from an `AssemblyLoad` event. Users retain the reliable on-demand `Test-DPLibraryConflict` command.
+- Dependency loading must continue to produce the existing result objects and statuses.
+
+## Security and Reliability Constraints
+
+- No PowerShell script block may be registered directly as an `AssemblyLoad` or `AssemblyResolve` CLR delegate.
+- Regression tests that exercise process-fatal behavior must run in an isolated child `pwsh` process with a bounded timeout.
+- Synthetic tests must not download modules, access the network, or depend on installed Az/Exchange modules.
+- Tests must use synchronization primitives or synchronous child-process completion, not timing-only sleeps.
+- If a resolver is required, it must not probe the current directory, `PATH`, `PSModulePath`, or caller-provided locations.
+
+## Verification
+
+- A source guard rejects direct `AssemblyLoadEventHandler` and `ResolveEventHandler` script-block casts.
+- A synthetic two-assembly dependency test proves dependency loading on the supported runtime.
+- A child-process test imports and exercises the module without `PSInvalidOperationException` or abnormal termination.
+- Analyzer, unit tests, issue reproduction integration tests, and the complete repository build pass.
+

--- a/src/DLLPickle/Private/Invoke-DPConflictCheck.ps1
+++ b/src/DLLPickle/Private/Invoke-DPConflictCheck.ps1
@@ -1,4 +1,4 @@
-﻿function Invoke-DPConflictCheck {
+function Invoke-DPConflictCheck {
     <#
     .SYNOPSIS
         Warns about known incompatible module pairs that are already loaded.

--- a/src/DLLPickle/Private/Invoke-DPConflictCheck.ps1
+++ b/src/DLLPickle/Private/Invoke-DPConflictCheck.ps1
@@ -1,22 +1,13 @@
-function Invoke-DPConflictCheck {
+﻿function Invoke-DPConflictCheck {
     <#
     .SYNOPSIS
-        After preload, warns about (or arms a best-effort one-shot warning for) known incompatible
-        module pairs.
+        Warns about known incompatible module pairs that are already loaded.
     .DESCRIPTION
-        For each known conflict: if every module is already loaded, warn immediately. Otherwise, if
-        every module is installed (so the clash can still happen later), register a single AssemblyLoad
-        handler that warns only once every module in the pair has actually been co-loaded, then
-        unregisters itself.
-
-        Best-effort and advisory: it is fully guarded and never throws, is skipped under Constrained
-        Language Mode, and warns at most once per conflict per session. It cannot pre-empt a module
-        whose import fails outright before any of its assemblies load (a rejected load raises no
-        AssemblyLoad event), and it keys on imported modules, so a module removed with Remove-Module
-        after its assemblies are already resident is not re-detected. Test-DPLibraryConflict is the
-        reliable on-demand check; the authoritative protection is the separate-process workaround.
+        Compares the shipped known-conflict data with modules currently loaded in the session and
+        emits each conflict warning at most once. This advisory check never installs CLR assembly
+        event handlers; use Test-DPLibraryConflict for a reliable on-demand check after later imports.
     .PARAMETER KnownConflictsPath
-        Optional override for the knownConflicts file (testing). Defaults to the shipped file.
+        Optional override for the known-conflicts file used by tests. Defaults to the shipped file.
     #>
     [CmdletBinding()]
     param(
@@ -26,102 +17,42 @@ function Invoke-DPConflictCheck {
 
     process {
         try {
-            if ($ExecutionContext.SessionState.LanguageMode -eq [System.Management.Automation.PSLanguageMode]::ConstrainedLanguage) {
-                Write-Verbose 'Constrained Language Mode: skipping conflict-watch arming.'
+            $Conflicts = Get-DPKnownConflict -Path $KnownConflictsPath
+            if (@($Conflicts).Count -eq 0) {
                 return
             }
 
-            $Conflicts = Get-DPKnownConflict -Path $KnownConflictsPath
-            if (@($Conflicts).Count -eq 0) { return }
-
-            # Warn/arm at most once per conflict per session: repeated Import-DPLibrary calls must not
-            # stack AssemblyLoad handlers or re-emit the same warning. Module-scoped so it persists.
             if (-not $script:DPConflictHandled) {
-                $script:DPConflictHandled = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+                $script:DPConflictHandled = [System.Collections.Generic.HashSet[string]]::new(
+                    [System.StringComparer]::OrdinalIgnoreCase
+                )
             }
 
             $LoadedNames = @(Get-Module | Select-Object -ExpandProperty Name)
-
             foreach ($Conflict in $Conflicts) {
                 $Modules = @($Conflict.modules)
-                if ($Modules.Count -eq 0) { continue }
-
-                $ConflictId = [string]$Conflict.id
-                if ($ConflictId -and $script:DPConflictHandled.Contains($ConflictId)) { continue }
-
-                $LoadedCount = @($Modules | Where-Object { $LoadedNames -contains $_ }).Count
-                if ($LoadedCount -eq $Modules.Count) {
-                    Write-Warning -Message (Format-DPConflictWarning -Conflict $Conflict)
-                    if ($ConflictId) { [void]$script:DPConflictHandled.Add($ConflictId) }
+                if ($Modules.Count -eq 0) {
                     continue
                 }
 
-                # Arm a watch for the not-yet-loaded module(s). For each, collect ALL installed version
-                # base paths (a version-pinned import may load from a non-latest copy). Query only these
-                # specific module names, not all of PSModulePath. Arm only when every one is installed.
-                $NotLoaded = @($Modules | Where-Object { $LoadedNames -notcontains $_ })
-                $WatchedModule = [System.Collections.Generic.List[object]]::new()
-                $AllInstalled = $true
-                foreach ($Name in $NotLoaded) {
-                    # Normalize each base to end with a directory separator so the handler's StartsWith
-                    # check is a true directory-prefix match (e.g. '...\Az.Storage\' must not match a
-                    # sibling '...\Az.Storage.Custom\').
-                    $Bases = @(
-                        Get-Module -ListAvailable -Name $Name |
-                            ForEach-Object {
-                                if ($_.ModuleBase) {
-                                    $Full = [System.IO.Path]::GetFullPath($_.ModuleBase)
-                                    if (-not $Full.EndsWith([System.IO.Path]::DirectorySeparatorChar)) {
-                                        $Full += [System.IO.Path]::DirectorySeparatorChar
-                                    }
-                                    $Full
-                                }
-                            } |
-                            Select-Object -Unique
-                    )
-                    if ($Bases.Count -eq 0) { $AllInstalled = $false; break }
-                    $WatchedModule.Add([PSCustomObject]@{ Name = $Name; Bases = $Bases })
+                $ConflictId = [string]$Conflict.id
+                if ($ConflictId -and $script:DPConflictHandled.Contains($ConflictId)) {
+                    continue
                 }
-                if (-not $AllInstalled -or $WatchedModule.Count -eq 0) { continue }
 
-                # The handler marks a watched module "seen" when an assembly loads from any of its base
-                # paths, and warns only once EVERY watched module has been seen (i.e. the whole pair is
-                # co-loaded) - not when just one of them loads.
-                $State = [PSCustomObject]@{
-                    Conflict = $Conflict
-                    Watched  = $WatchedModule.ToArray()
-                    Seen     = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
-                    Handler  = $null
+                $LoadedCount = @($Modules | Where-Object { $LoadedNames -contains $_ }).Count
+                if ($LoadedCount -ne $Modules.Count) {
+                    continue
                 }
-                $State.Handler = [System.AssemblyLoadEventHandler]{
-                    param($EventSender, $LoadArgs)
-                    [void]$EventSender
-                    try {
-                        $Location = $LoadArgs.LoadedAssembly.Location
-                        if ($Location) {
-                            $FullLocation = [System.IO.Path]::GetFullPath($Location)
-                            foreach ($Module in $State.Watched) {
-                                foreach ($Base in $Module.Bases) {
-                                    if ($FullLocation.StartsWith($Base, [System.StringComparison]::OrdinalIgnoreCase)) {
-                                        [void]$State.Seen.Add($Module.Name)
-                                        break
-                                    }
-                                }
-                            }
-                            if ($State.Seen.Count -ge $State.Watched.Count) {
-                                Write-Warning -Message (Format-DPConflictWarning -Conflict $State.Conflict)
-                                [System.AppDomain]::CurrentDomain.remove_AssemblyLoad($State.Handler)
-                            }
-                        }
-                    } catch {
-                        Write-Verbose "AssemblyLoad conflict-watch handler error (advisory, suppressed): $_"
-                    }
-                }.GetNewClosure()
-                [System.AppDomain]::CurrentDomain.add_AssemblyLoad($State.Handler)
-                if ($ConflictId) { [void]$script:DPConflictHandled.Add($ConflictId) }
+
+                Write-Warning -Message (Format-DPConflictWarning -Conflict $Conflict)
+                if ($ConflictId) {
+                    [void]$script:DPConflictHandled.Add($ConflictId)
+                }
             }
         } catch {
             Write-Verbose "Conflict check skipped due to error: $_"
         }
     }
 }
+

--- a/src/DLLPickle/Public/Import-DPLibrary.ps1
+++ b/src/DLLPickle/Public/Import-DPLibrary.ps1
@@ -169,17 +169,6 @@
     $RetryCount = 0
     $LoadFailureDetailsByDLLName = @{}
     $InitiallyLoadedAssemblyKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
-    $AssemblyPathBySimpleName = @{}
-    foreach ($CandidateDLL in $DLLFiles) {
-        try {
-            $CandidateAssemblyName = [System.Reflection.AssemblyName]::GetAssemblyName($CandidateDLL.FullName)
-            if (-not $AssemblyPathBySimpleName.ContainsKey($CandidateAssemblyName.Name)) {
-                $AssemblyPathBySimpleName[$CandidateAssemblyName.Name] = $CandidateDLL.FullName
-            }
-        } catch {
-            Write-Verbose "Skipping resolver map entry for '$($CandidateDLL.Name)' because assembly metadata could not be read."
-        }
-    }
 
     function ConvertTo-DPPublicKeyTokenText {
         param([byte[]]$PublicKeyToken)
@@ -220,49 +209,6 @@
 
         return $NamesMatch -and $CulturesMatch -and $TokensMatch -and $VersionsMatch
     }
-
-    $AssemblyResolveHandler = [System.ResolveEventHandler] {
-        param ($ResolveSender, $ResolveArgs)
-
-        [void]$ResolveSender
-
-        try {
-            $RequestedAssemblyName = [System.Reflection.AssemblyName]::new($ResolveArgs.Name)
-        } catch {
-            return $null
-        }
-
-        $AlreadyLoadedAssembly = [System.AppDomain]::CurrentDomain.GetAssemblies() |
-            Where-Object {
-                $LoadedName = $_.GetName()
-                Test-DPAssemblyIdentityCompatible -CandidateAssemblyName $LoadedName -RequestedAssemblyName $RequestedAssemblyName
-            } | Select-Object -First 1
-        if ($AlreadyLoadedAssembly) {
-            return $AlreadyLoadedAssembly
-        }
-
-        if ($AssemblyPathBySimpleName.ContainsKey($RequestedAssemblyName.Name)) {
-            $ResolvedPath = $AssemblyPathBySimpleName[$RequestedAssemblyName.Name]
-            if (Test-Path -Path $ResolvedPath) {
-                try {
-                    $CandidateAssemblyName = [System.Reflection.AssemblyName]::GetAssemblyName($ResolvedPath)
-                } catch {
-                    return $null
-                }
-
-                if (Test-DPAssemblyIdentityCompatible -CandidateAssemblyName $CandidateAssemblyName -RequestedAssemblyName $RequestedAssemblyName) {
-                    try {
-                        return [System.Reflection.Assembly]::LoadFrom($ResolvedPath)
-                    } catch {
-                        return $null
-                    }
-                }
-            }
-        }
-
-        return $null
-    }
-    [System.AppDomain]::CurrentDomain.add_AssemblyResolve($AssemblyResolveHandler)
 
     foreach ($Loaded in [System.AppDomain]::CurrentDomain.GetAssemblies()) {
         $LoadedName = $Loaded.GetName()
@@ -330,158 +276,154 @@
         }
     }
 
-    try {
-        while ($DLLFileQueue.Count -gt 0 -and $RetryCount -lt $MaxRetries) {
-            $UnresolvedDLLFiles = [System.Collections.Generic.List[object]]::new()
+    while ($DLLFileQueue.Count -gt 0 -and $RetryCount -lt $MaxRetries) {
+        $UnresolvedDLLFiles = [System.Collections.Generic.List[object]]::new()
 
-            foreach ($DLLFile in $DLLFileQueue) {
-                $FilePath = $DLLFile.FullName
+        foreach ($DLLFile in $DLLFileQueue) {
+            $FilePath = $DLLFile.FullName
 
-                try {
-                    # Check if assembly is already loaded
-                    $AssemblyName = [System.Reflection.AssemblyName]::GetAssemblyName($FilePath)
-                    $LoadedAssembly = [System.AppDomain]::CurrentDomain.GetAssemblies() |
-                        Where-Object {
-                            $LoadedName = $_.GetName()
-                            Test-DPAssemblyIdentityCompatible -CandidateAssemblyName $LoadedName -RequestedAssemblyName $AssemblyName -AllowNewerVersion
-                        } |
-                        Select-Object -First 1
+            try {
+                # Check if assembly is already loaded
+                $AssemblyName = [System.Reflection.AssemblyName]::GetAssemblyName($FilePath)
+                $LoadedAssembly = [System.AppDomain]::CurrentDomain.GetAssemblies() |
+                    Where-Object {
+                        $LoadedName = $_.GetName()
+                        Test-DPAssemblyIdentityCompatible -CandidateAssemblyName $LoadedName -RequestedAssemblyName $AssemblyName -AllowNewerVersion
+                    } |
+                    Select-Object -First 1
 
-                    if ($LoadedAssembly) {
-                        $LoadedAssemblyName = $LoadedAssembly.GetName()
-                        $Status = if ($InitiallyLoadedAssemblyKeys.Contains($LoadedAssemblyName.FullName)) { 'Already Loaded' } else { 'Imported' }
-                        if ($Status -eq 'Already Loaded') {
-                            Write-Verbose "Assembly already loaded: $($DLLFile.BaseName)"
-                        } else {
-                            Write-Verbose "Assembly was loaded during this invocation: $($DLLFile.BaseName)"
+                if ($LoadedAssembly) {
+                    $LoadedAssemblyName = $LoadedAssembly.GetName()
+                    $Status = if ($InitiallyLoadedAssemblyKeys.Contains($LoadedAssemblyName.FullName)) { 'Already Loaded' } else { 'Imported' }
+                    if ($Status -eq 'Already Loaded') {
+                        Write-Verbose "Assembly already loaded: $($DLLFile.BaseName)"
+                    } else {
+                        Write-Verbose "Assembly was loaded during this invocation: $($DLLFile.BaseName)"
+                    }
+                    [void]$Results.Add([PSCustomObject]@{
+                            PSTypeName      = 'DLLPickle.ImportDPLibraryResult'
+                            DLLName         = $DLLFile.Name
+                            AssemblyName    = $LoadedAssemblyName.Name
+                            AssemblyVersion = $LoadedAssemblyName.Version.ToString()
+                            Status          = $Status
+                            Error           = $null
+                        })
+                    [void]$ResultDLLNames.Add($DLLFile.Name)
+                } else {
+                    $RuntimeAssemblyName = $null
+                    if ($TrustedPlatformAssemblyPathByName.ContainsKey($AssemblyName.Name)) {
+                        try {
+                            $CandidateRuntimeAssemblyName = [System.Reflection.AssemblyName]::GetAssemblyName($TrustedPlatformAssemblyPathByName[$AssemblyName.Name])
+                        } catch {
+                            $CandidateRuntimeAssemblyName = $null
                         }
+
+                        if ($CandidateRuntimeAssemblyName) {
+                            $CulturesMatch = [string]$CandidateRuntimeAssemblyName.CultureName -eq [string]$AssemblyName.CultureName
+                            $CandidateTokenText = ConvertTo-DPPublicKeyTokenText -PublicKeyToken $CandidateRuntimeAssemblyName.GetPublicKeyToken()
+                            $RequestedTokenText = ConvertTo-DPPublicKeyTokenText -PublicKeyToken $AssemblyName.GetPublicKeyToken()
+                            $TokensMatch = $CandidateTokenText -eq $RequestedTokenText
+                            if (
+                                $CulturesMatch -and
+                                $TokensMatch -and
+                                $CandidateRuntimeAssemblyName.Version.Major -ge $AssemblyName.Version.Major
+                            ) {
+                                $RuntimeAssemblyName = $CandidateRuntimeAssemblyName
+                            }
+                        }
+                    }
+
+                    if ($RuntimeAssemblyName) {
+                        Write-Verbose "Runtime provides compatible assembly: $($AssemblyName.Name) $($RuntimeAssemblyName.Version)"
                         [void]$Results.Add([PSCustomObject]@{
                                 PSTypeName      = 'DLLPickle.ImportDPLibraryResult'
                                 DLLName         = $DLLFile.Name
-                                AssemblyName    = $LoadedAssemblyName.Name
-                                AssemblyVersion = $LoadedAssemblyName.Version.ToString()
-                                Status          = $Status
+                                AssemblyName    = $RuntimeAssemblyName.Name
+                                AssemblyVersion = $RuntimeAssemblyName.Version.ToString()
+                                Status          = 'Already Loaded'
                                 Error           = $null
                             })
                         [void]$ResultDLLNames.Add($DLLFile.Name)
                     } else {
-                        $RuntimeAssemblyName = $null
-                        if ($TrustedPlatformAssemblyPathByName.ContainsKey($AssemblyName.Name)) {
-                            try {
-                                $CandidateRuntimeAssemblyName = [System.Reflection.AssemblyName]::GetAssemblyName($TrustedPlatformAssemblyPathByName[$AssemblyName.Name])
-                            } catch {
-                                $CandidateRuntimeAssemblyName = $null
-                            }
-
-                            if ($CandidateRuntimeAssemblyName) {
-                                $CulturesMatch = [string]$CandidateRuntimeAssemblyName.CultureName -eq [string]$AssemblyName.CultureName
-                                $CandidateTokenText = ConvertTo-DPPublicKeyTokenText -PublicKeyToken $CandidateRuntimeAssemblyName.GetPublicKeyToken()
-                                $RequestedTokenText = ConvertTo-DPPublicKeyTokenText -PublicKeyToken $AssemblyName.GetPublicKeyToken()
-                                $TokensMatch = $CandidateTokenText -eq $RequestedTokenText
-                                if (
-                                    $CulturesMatch -and
-                                    $TokensMatch -and
-                                    $CandidateRuntimeAssemblyName.Version.Major -ge $AssemblyName.Version.Major
-                                ) {
-                                    $RuntimeAssemblyName = $CandidateRuntimeAssemblyName
-                                }
-                            }
-                        }
-
-                        if ($RuntimeAssemblyName) {
-                            Write-Verbose "Runtime provides compatible assembly: $($AssemblyName.Name) $($RuntimeAssemblyName.Version)"
-                            [void]$Results.Add([PSCustomObject]@{
-                                    PSTypeName      = 'DLLPickle.ImportDPLibraryResult'
-                                    DLLName         = $DLLFile.Name
-                                    AssemblyName    = $RuntimeAssemblyName.Name
-                                    AssemblyVersion = $RuntimeAssemblyName.Version.ToString()
-                                    Status          = 'Already Loaded'
-                                    Error           = $null
-                                })
-                            [void]$ResultDLLNames.Add($DLLFile.Name)
-                        } else {
-                            Add-Type -Path $FilePath
-                            Write-Verbose "Successfully imported: $($DLLFile.BaseName)"
-                            [void]$Results.Add([PSCustomObject]@{
-                                    PSTypeName      = 'DLLPickle.ImportDPLibraryResult'
-                                    DLLName         = $DLLFile.Name
-                                    AssemblyName    = $AssemblyName.Name
-                                    AssemblyVersion = $AssemblyName.Version.ToString()
-                                    Status          = 'Imported'
-                                    Error           = $null
-                                })
-                            [void]$ResultDLLNames.Add($DLLFile.Name)
-                        }
+                        Add-Type -Path $FilePath
+                        Write-Verbose "Successfully imported: $($DLLFile.BaseName)"
+                        [void]$Results.Add([PSCustomObject]@{
+                                PSTypeName      = 'DLLPickle.ImportDPLibraryResult'
+                                DLLName         = $DLLFile.Name
+                                AssemblyName    = $AssemblyName.Name
+                                AssemblyVersion = $AssemblyName.Version.ToString()
+                                Status          = 'Imported'
+                                Error           = $null
+                            })
+                        [void]$ResultDLLNames.Add($DLLFile.Name)
                     }
-                } catch [System.Reflection.ReflectionTypeLoadException] {
-                    # Assembly failed to load; dependencies may not be loaded yet. Retry later.
-                    [void]$UnresolvedDLLFiles.Add($DLLFile)
-                    $LoaderExceptions = $_.Exception.LoaderExceptions
-                    $ErrorMessage = $_.Exception.Message
-                    $LoadFailureDetailsByDLLName[$DLLFile.Name] = [PSCustomObject]@{
-                        ErrorMessage     = $ErrorMessage
-                        LoaderExceptions = $LoaderExceptions
-                    }
-
-                    if ($RetryCount -eq 0) {
-                        # Only show verbose output on first attempt; dependencies may resolve on retry
-
-                        if ($ShowLoaderExceptions -and $LoaderExceptions) {
-                            Write-Verbose "Failed to import $($DLLFile.Name): $ErrorMessage"
-                            Write-Verbose "Loader Exceptions ($($LoaderExceptions.Count) total):"
-                            foreach ($LoaderException in $LoaderExceptions | Select-Object -First 5) {
-                                Write-Verbose "  - $($LoaderException.Message)"
-                            }
-                            if ($LoaderExceptions.Count -gt 5) {
-                                Write-Verbose "  ... and $($LoaderExceptions.Count - 5) more exceptions"
-                            }
-                        } else {
-                            Write-Verbose "Failed to import $($DLLFile.Name) (attempt $(($RetryCount + 1))/$MaxRetries): $ErrorMessage"
-                            if (-not $ShowLoaderExceptions) {
-                                Write-Verbose 'Use -ShowLoaderExceptions to see detailed loader exception information'
-                            }
-                        }
-                    }
-                } catch {
-                    # Other error; do not retry
-                    Write-Warning "Failed to import $($DLLFile.Name): $_"
-                    [void]$Results.Add([PSCustomObject]@{
-                            PSTypeName      = 'DLLPickle.ImportDPLibraryResult'
-                            DLLName         = $DLLFile.Name
-                            AssemblyName    = $null
-                            AssemblyVersion = $null
-                            Status          = 'Failed'
-                            Error           = $_.Exception.Message
-                        })
-                    [void]$ResultDLLNames.Add($DLLFile.Name)
                 }
-            }
+            } catch [System.Reflection.ReflectionTypeLoadException] {
+                # Assembly failed to load; dependencies may not be loaded yet. Retry later.
+                [void]$UnresolvedDLLFiles.Add($DLLFile)
+                $LoaderExceptions = $_.Exception.LoaderExceptions
+                $ErrorMessage = $_.Exception.Message
+                $LoadFailureDetailsByDLLName[$DLLFile.Name] = [PSCustomObject]@{
+                    ErrorMessage     = $ErrorMessage
+                    LoaderExceptions = $LoaderExceptions
+                }
 
-            # If all assemblies loaded successfully, exit the retry loop
-            if ($UnresolvedDLLFiles.Count -eq 0) {
+                if ($RetryCount -eq 0) {
+                    # Only show verbose output on first attempt; dependencies may resolve on retry
+
+                    if ($ShowLoaderExceptions -and $LoaderExceptions) {
+                        Write-Verbose "Failed to import $($DLLFile.Name): $ErrorMessage"
+                        Write-Verbose "Loader Exceptions ($($LoaderExceptions.Count) total):"
+                        foreach ($LoaderException in $LoaderExceptions | Select-Object -First 5) {
+                            Write-Verbose "  - $($LoaderException.Message)"
+                        }
+                        if ($LoaderExceptions.Count -gt 5) {
+                            Write-Verbose "  ... and $($LoaderExceptions.Count - 5) more exceptions"
+                        }
+                    } else {
+                        Write-Verbose "Failed to import $($DLLFile.Name) (attempt $(($RetryCount + 1))/$MaxRetries): $ErrorMessage"
+                        if (-not $ShowLoaderExceptions) {
+                            Write-Verbose 'Use -ShowLoaderExceptions to see detailed loader exception information'
+                        }
+                    }
+                }
+            } catch {
+                # Other error; do not retry
+                Write-Warning "Failed to import $($DLLFile.Name): $_"
+                [void]$Results.Add([PSCustomObject]@{
+                        PSTypeName      = 'DLLPickle.ImportDPLibraryResult'
+                        DLLName         = $DLLFile.Name
+                        AssemblyName    = $null
+                        AssemblyVersion = $null
+                        Status          = 'Failed'
+                        Error           = $_.Exception.Message
+                    })
+                [void]$ResultDLLNames.Add($DLLFile.Name)
+            }
+        }
+
+        # If all assemblies loaded successfully, exit the retry loop
+        if ($UnresolvedDLLFiles.Count -eq 0) {
+            $DLLFileQueue = @()
+            break
+        }
+
+        # If no progress was made (same failures as last iteration), record failures and exit
+        if ($UnresolvedDLLFiles.Count -eq $DLLFileQueue.Count) {
+            $RetryCount++
+            if ($RetryCount -ge $MaxRetries) {
+                # Record remaining unresolved DLLs as failures
+                foreach ($DLLFile in $UnresolvedDLLFiles) {
+                    & $RecordFinalFailure $DLLFile
+                }
                 $DLLFileQueue = @()
                 break
             }
-
-            # If no progress was made (same failures as last iteration), record failures and exit
-            if ($UnresolvedDLLFiles.Count -eq $DLLFileQueue.Count) {
-                $RetryCount++
-                if ($RetryCount -ge $MaxRetries) {
-                    # Record remaining unresolved DLLs as failures
-                    foreach ($DLLFile in $UnresolvedDLLFiles) {
-                        & $RecordFinalFailure $DLLFile
-                    }
-                    $DLLFileQueue = @()
-                    break
-                }
-            } else {
-                $RetryCount++
-            }
-
-            $DLLFileQueue = $UnresolvedDLLFiles
+        } else {
+            $RetryCount++
         }
-    } finally {
-        [System.AppDomain]::CurrentDomain.remove_AssemblyResolve($AssemblyResolveHandler)
+
+        $DLLFileQueue = $UnresolvedDLLFiles
     }
 
     if ($DLLFileQueue.Count -gt 0) {

--- a/tests/Integration/DLLPickle.Issue242.BackgroundEvents.Tests.ps1
+++ b/tests/Integration/DLLPickle.Issue242.BackgroundEvents.Tests.ps1
@@ -1,0 +1,82 @@
+BeforeAll {
+    Set-Location -Path $PSScriptRoot
+    $script:ProjectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+    $script:BuiltModuleManifestPath = Join-Path $script:ProjectRoot 'module\DLLPickle\DLLPickle.psd1'
+    $script:ScenarioOutputRoot = Join-Path -Path $script:ProjectRoot -ChildPath 'artifacts\testOutput\IssueRepro'
+    $null = New-Item -Path $script:ScenarioOutputRoot -ItemType Directory -Force
+    . (Join-Path $PSScriptRoot 'Invoke-DLLPickleScenario.ps1')
+
+    function Initialize-Issue242SyntheticModule {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$RootPath,
+
+            [Parameter(Mandatory)]
+            [string]$Name
+        )
+
+        $ModuleDirectory = Join-Path -Path $RootPath -ChildPath ([IO.Path]::Combine($Name, '1.0.0'))
+        $null = New-Item -Path $ModuleDirectory -ItemType Directory -Force
+        Set-Content -LiteralPath (Join-Path $ModuleDirectory "$Name.psm1") -Value '' -Encoding UTF8
+        New-ModuleManifest `
+            -Path (Join-Path $ModuleDirectory "$Name.psd1") `
+            -RootModule "$Name.psm1" `
+            -ModuleVersion '1.0.0' `
+            -ErrorAction Stop
+    }
+}
+
+Describe 'Issue 242 background assembly event regression' -Tag 'Integration', 'Issue242' {
+    BeforeEach {
+        $script:SyntheticModuleRoot = Join-Path -Path $TestDrive -ChildPath 'Modules'
+        Initialize-Issue242SyntheticModule -RootPath $script:SyntheticModuleRoot -Name 'Az.Storage'
+        Initialize-Issue242SyntheticModule -RootPath $script:SyntheticModuleRoot -Name 'ExchangeOnlineManagement'
+    }
+
+    It 'survives an assembly load raised from a thread without a PowerShell runspace' {
+        $BackgroundLoadStep = @'
+Add-Type -TypeDefinition @"
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading.Tasks;
+
+public static class DLLPickleIssue242Probe {
+    public static Task LoadOnWorkerThreadAsync() {
+        return Task.Run(() => {
+            var name = new AssemblyName("DLLPickle.Issue242." + Guid.NewGuid().ToString("N"));
+            AssemblyBuilder.DefineDynamicAssembly(name, AssemblyBuilderAccess.Run);
+        });
+    }
+}
+"@
+[DLLPickleIssue242Probe]::LoadOnWorkerThreadAsync().GetAwaiter().GetResult()
+'BACKGROUND_ASSEMBLY_LOAD_OK'
+'@
+
+        $Result = Invoke-DLLPickleScenario `
+            -Name 'Issue242-BackgroundAssemblyLoad' `
+            -ModuleManifestPath $script:BuiltModuleManifestPath `
+            -AdditionalModulePath $script:SyntheticModuleRoot `
+            -OutputPath (Join-Path $script:ScenarioOutputRoot 'Issue242-BackgroundAssemblyLoad.json') `
+            -TimeoutSeconds 30 `
+            -Step @(
+                @{
+                    Name = 'Import DLLPickle'
+                    Script = 'Import-Module $ScenarioModuleManifestPath -Force; Import-DPLibrary -SuppressLogo'
+                }
+                @{
+                    Name = 'Load assembly on worker thread'
+                    Script = $BackgroundLoadStep
+                }
+            )
+
+        $Result.Success | Should -BeTrue
+        $Result.ProcessExitCode | Should -Be 0
+        ($Result.ProcessOutput -join [Environment]::NewLine) | Should -Not -Match 'PSInvalidOperationException|There is no Runspace available'
+        $BackgroundStep = $Result.Steps | Where-Object Name -eq 'Load assembly on worker thread'
+        $BackgroundStep.Success | Should -BeTrue
+        ($BackgroundStep.Output -join [Environment]::NewLine) | Should -Match 'BACKGROUND_ASSEMBLY_LOAD_OK'
+    }
+}

--- a/tests/Unit/AssemblyEventSafety.Tests.ps1
+++ b/tests/Unit/AssemblyEventSafety.Tests.ps1
@@ -1,0 +1,18 @@
+BeforeAll {
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+}
+
+Describe 'Assembly event safety' -Tag 'Unit' {
+    It 'does not register PowerShell script blocks as CLR assembly event delegates' {
+        $UnsafeSourceFiles = @(
+            Get-ChildItem -LiteralPath (Join-Path $RepoRoot 'src\DLLPickle') -Filter '*.ps1' -File -Recurse |
+                Where-Object {
+                    (Get-Content -LiteralPath $_.FullName -Raw) -match
+                        '\[System\.(AssemblyLoadEventHandler|ResolveEventHandler)\]\s*\{'
+                } |
+                Select-Object -ExpandProperty FullName
+        )
+
+        $UnsafeSourceFiles | Should -BeNullOrEmpty
+    }
+}

--- a/tests/Unit/Import-DPLibrary.Tests.ps1
+++ b/tests/Unit/Import-DPLibrary.Tests.ps1
@@ -1,5 +1,6 @@
 ﻿BeforeAll {
     Set-Location -Path $PSScriptRoot
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
     . (Resolve-Path ([System.IO.Path]::Combine('..', '..', 'src', 'DLLPickle', 'Public', 'Get-DPConfig.ps1')))
     . (Resolve-Path ([System.IO.Path]::Combine('..', '..', 'src', 'DLLPickle', 'Private', 'Resolve-DPDLLLoadOrder.ps1')))
     . (Resolve-Path ([System.IO.Path]::Combine('..', '..', 'src', 'DLLPickle', 'Public', 'Import-DPLibrary.ps1')))
@@ -151,6 +152,74 @@ Describe 'Import-DPLibrary' -Tag 'Unit' {
             $Result[0].DLLName | Should -Be 'InvalidLibrary.dll'
             $Result[0].Status | Should -Be 'Failed'
             $Result[0].Error | Should -Not -BeNullOrEmpty
+        }
+
+        It 'loads an ordered synthetic transitive dependency without relying on resolver callbacks' {
+            $FixtureRoot = Join-Path -Path $TestDrive -ChildPath 'SyntheticDependencyModule'
+            $Payload = [ordered]@{
+                RepoRoot    = $RepoRoot
+                FixtureRoot = $FixtureRoot
+                FixtureId   = 'Fixture' + [guid]::NewGuid().ToString('N')
+            }
+            $PayloadBase64 = [Convert]::ToBase64String(
+                [Text.Encoding]::UTF8.GetBytes(($Payload | ConvertTo-Json -Compress))
+            )
+            $ChildScript = @'
+$ErrorActionPreference = 'Stop'
+$Payload = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('__PAYLOAD__')) | ConvertFrom-Json
+$TfmDirectory = Join-Path -Path $Payload.FixtureRoot -ChildPath ([IO.Path]::Combine('bin', 'net8.0'))
+$null = New-Item -Path $TfmDirectory -ItemType Directory -Force
+$DependencyPath = Join-Path -Path $TfmDirectory -ChildPath 'A.Synthetic.Dependency.dll'
+$ConsumerPath = Join-Path -Path $TfmDirectory -ChildPath 'Z.Synthetic.Consumer.dll'
+
+$DependencySource = @"
+namespace $($Payload.FixtureId) {
+    public static class Dependency {
+        public static string GetValue() { return "resolved"; }
+    }
+}
+"@
+Add-Type -TypeDefinition $DependencySource -OutputAssembly $DependencyPath -ErrorAction Stop
+
+$ConsumerSource = @"
+namespace $($Payload.FixtureId) {
+    public static class Consumer {
+        public static string GetValue() { return Dependency.GetValue(); }
+    }
+}
+"@
+Add-Type -TypeDefinition $ConsumerSource -ReferencedAssemblies $DependencyPath -OutputAssembly $ConsumerPath -ErrorAction Stop
+
+. (Join-Path $Payload.RepoRoot 'src\DLLPickle\Public\Get-DPConfig.ps1')
+. (Join-Path $Payload.RepoRoot 'src\DLLPickle\Private\Resolve-DPDLLLoadOrder.ps1')
+. (Join-Path $Payload.RepoRoot 'src\DLLPickle\Public\Import-DPLibrary.ps1')
+function Get-DPConfig { [PSCustomObject]@{ SkipLibraries = @(); ShowLogo = $false } }
+function Invoke-DPConflictCheck {}
+$global:PSModuleRoot = $Payload.FixtureRoot
+
+$Result = @(Import-DPLibrary -SuppressLogo -WarningAction SilentlyContinue)
+if ($Result.Count -ne 2 -or @($Result | Where-Object Status -eq 'Failed').Count -gt 0) {
+    throw "Synthetic dependency import failed: $($Result | ConvertTo-Json -Compress)"
+}
+
+$ConsumerAssemblyName = [Reflection.AssemblyName]::GetAssemblyName($ConsumerPath).Name
+$ConsumerAssembly = [AppDomain]::CurrentDomain.GetAssemblies() |
+    Where-Object { $_.GetName().Name -eq $ConsumerAssemblyName } |
+    Select-Object -First 1
+$ConsumerType = $ConsumerAssembly.GetType("$($Payload.FixtureId).Consumer", $true)
+if ($ConsumerType.GetMethod('GetValue').Invoke($null, @()) -ne 'resolved') {
+    throw 'Synthetic consumer did not resolve its dependency.'
+}
+'SYNTHETIC_DEPENDENCY_OK'
+'@.Replace('__PAYLOAD__', $PayloadBase64)
+            $ChildScriptPath = Join-Path -Path $TestDrive -ChildPath 'Invoke-SyntheticDependencyTest.ps1'
+            Set-Content -LiteralPath $ChildScriptPath -Value $ChildScript -Encoding UTF8
+
+            $ProcessOutput = @(& pwsh -NoProfile -NonInteractive -File $ChildScriptPath 2>&1)
+            $ProcessExitCode = $LASTEXITCODE
+
+            $ProcessExitCode | Should -Be 0 -Because ($ProcessOutput -join [Environment]::NewLine)
+            ($ProcessOutput -join [Environment]::NewLine) | Should -Match 'SYNTHETIC_DEPENDENCY_OK'
         }
     }
 

--- a/tests/Unit/KnownConflicts.Tests.ps1
+++ b/tests/Unit/KnownConflicts.Tests.ps1
@@ -1,8 +1,9 @@
-BeforeAll {
+﻿BeforeAll {
     $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
     . (Join-Path $RepoRoot 'src\DLLPickle\Private\Test-DPModuleConflict.ps1')
     . (Join-Path $RepoRoot 'src\DLLPickle\Private\Get-DPKnownConflict.ps1')
     . (Join-Path $RepoRoot 'src\DLLPickle\Private\Format-DPConflictWarning.ps1')
+    . (Join-Path $RepoRoot 'src\DLLPickle\Private\Invoke-DPConflictCheck.ps1')
     . (Join-Path $RepoRoot 'src\DLLPickle\Public\Test-DPLibraryConflict.ps1')
 
     $SampleConflict = [PSCustomObject]@{
@@ -120,5 +121,50 @@ Describe 'Test-DPLibraryConflict' -Tag 'Unit' {
         $Active = Test-DPLibraryConflict -KnownConflictsPath $UnloadedPairPath -WarningVariable Warnings -WarningAction SilentlyContinue
         @($Active) | Should -BeNullOrEmpty
         @($Warnings) | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Invoke-DPConflictCheck' -Tag 'Unit' {
+    BeforeEach {
+        $script:DPConflictHandled = $null
+        $LoadedPairPath = Join-Path $TestDrive 'invoke-loaded-pair.json'
+        ConvertTo-Json -Depth 20 -InputObject @(
+            [PSCustomObject]@{
+                id         = 'invoke-loaded'
+                modules    = @('Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Utility')
+                assembly   = 'x'
+                issue      = '174'
+                reason     = 'r'
+                workaround = 'w'
+            }
+        ) | Set-Content -LiteralPath $LoadedPairPath -Encoding utf8
+    }
+
+    It 'warns only once for a conflict that is already loaded' {
+        $Warnings = @()
+
+        Invoke-DPConflictCheck -KnownConflictsPath $LoadedPairPath -WarningVariable +Warnings -WarningAction SilentlyContinue
+        Invoke-DPConflictCheck -KnownConflictsPath $LoadedPairPath -WarningVariable +Warnings -WarningAction SilentlyContinue
+
+        @($Warnings) | Should -HaveCount 1
+        $Warnings[0].Message | Should -Match 'Microsoft.PowerShell.Management'
+    }
+
+    It 'does not mark an unloaded conflict as handled' {
+        $UnloadedPairPath = Join-Path $TestDrive 'invoke-unloaded-pair.json'
+        ConvertTo-Json -Depth 20 -InputObject @(
+            [PSCustomObject]@{
+                id         = 'invoke-unloaded'
+                modules    = @('No.Such.ModuleA', 'No.Such.ModuleB')
+                assembly   = 'x'
+                issue      = '174'
+                reason     = 'r'
+                workaround = 'w'
+            }
+        ) | Set-Content -LiteralPath $UnloadedPairPath -Encoding utf8
+
+        Invoke-DPConflictCheck -KnownConflictsPath $UnloadedPairPath -WarningAction SilentlyContinue
+
+        $script:DPConflictHandled.Contains('invoke-unloaded') | Should -BeFalse
     }
 }

--- a/tests/Unit/KnownConflicts.Tests.ps1
+++ b/tests/Unit/KnownConflicts.Tests.ps1
@@ -1,4 +1,4 @@
-﻿BeforeAll {
+BeforeAll {
     $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
     . (Join-Path $RepoRoot 'src\DLLPickle\Private\Test-DPModuleConflict.ps1')
     . (Join-Path $RepoRoot 'src\DLLPickle\Private\Get-DPKnownConflict.ps1')


### PR DESCRIPTION
## Summary

- remove the PowerShell script-block delegates registered for `AssemblyLoad` and `AssemblyResolve`
- retain dependency-aware assembly ordering and retry behavior without adding a C# trampoline
- replace future-load conflict watching with an immediate, once-per-session advisory check
- add source-safety, synthetic dependency, conflict-check, and isolated background-thread regression coverage
- document the behavior change and deletion-experiment decision

## Root cause

CLR assembly events can execute on threads without a PowerShell runspace. PowerShell attempts to obtain a runspace before entering a script-block delegate, so the existing handlers could throw an unhandled `PSInvalidOperationException` before their internal error handling ran.

## Resolver decision

The resolver was deleted first and the dependency-ordering test suite was run as a decision gate. The synthetic transitive-dependency scenario passed without it, so no C# trampoline or replacement resolver was added. This avoids retaining global event subscriptions and runspace manipulation without demonstrated need.

## Impact

`Import-DPLibrary` no longer leaves PowerShell callbacks reachable from arbitrary CLR threads. Known conflicts already present are still warned once; conflicts introduced later can be checked explicitly with `Test-DPLibraryConflict`.

## Validation

- `Invoke-Build -File ./build/DLLPickle.Build.ps1 -Task Analyze,Test` — 157 passed, 0 failed
- `Invoke-Build -File ./build/DLLPickle.Build.ps1 -Task IssueReproTest` — 11 passed, 0 failed, 3 live-reproduction cases not run
- `Invoke-Build -File ./build/DLLPickle.Build.ps1` — 22 tasks, 0 errors
- `git diff --check`

Closes #242