### PR TITLE
docs: refresh Architecture and core design-decision docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Line-ending policy for DLLPickle.
+#
+# Markdown documentation is authored and reviewed on Windows; normalize it so the
+# repository blob is LF and the working tree is CRLF on every platform. This keeps
+# future edits from producing spurious CRLF/LF churn in diffs.
+*.md text eol=crlf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Import-DPLibrary` no longer registers PowerShell script blocks as CLR `AssemblyResolve` or `AssemblyLoad` event handlers. Those events can run on threads without a PowerShell runspace and terminate the process with `PSInvalidOperationException` (#242).
 - Dependency loading now relies on the supported-runtime dependency graph, deterministic fallback ordering, and retries. Synthetic transitive-dependency coverage confirmed that the legacy Windows PowerShell 5.1 resolver is not required on PowerShell 7.4+ / .NET 8.
 
+### Documentation
+
+- Refreshed `docs/Architecture.md` and the runtime/dependency docs around the core design decisions. Made the **two-tier platform-support contract** explicit: the automated `Import-DPLibrary` / `Import-DPBaseProfile` preloader is **PowerShell 7.4+ / .NET 8 only**, while the inspection/diagnostic helpers are **cross-edition by design** so they can guide a *manual* fix for Windows PowerShell 5.1 users.
+- Added a **Release & dependency-update contract** section (Architecture §8) covering the publish trigger (bundle-path gate **and** Conventional-Commit version gate) and the intended dependency lifecycle: minor/patch → TFM-aligned + tested + merged with a detailed comment → **minor** release; major → tested **draft PR with fully detailed notes**, not auto-merged or auto-published.
+- Corrected `DEPENDENCIES.md`: the MSAL / IdentityModel families use **major-locked floating** references (`N.*`) with `packages.lock.json` pinning the resolved version — not the exact pins previously documented.
+- Recorded the current automation gaps against the intended contract (the Dependabot `deps:` commit prefix is not a release prefix, so auto-merged dependency bumps do not publish on their own; the major-version draft-PR flow and an explicit TFM-alignment check are not yet automated). **No code or workflow behavior changed in this revision.**
+
 ## [2.2.0] - 2026-06-02
 
 > Adds proactive detection of the Az.Storage + ExchangeOnlineManagement OData incompatibility (#174) and a public conflict check, plus release-pipeline and CI hardening. The bundled assemblies are **unchanged** from 2.1.2.

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -9,6 +9,17 @@ DLLPickle now targets **PowerShell 7.4+** with a single **net8.0** runtime
 profile. Legacy Windows PowerShell 5.1 and .NET Framework dependency paths are
 no longer supported.
 
+The *automated* fix (`Import-DPLibrary` / `Import-DPBaseProfile`) requires
+PowerShell 7.4+ / .NET 8 because it depends on `AssemblyLoadContext`. The
+*inspection / diagnostic* helpers (`Find-DLLInPSModulePath`,
+`Get-ModuleImportCandidate`, `Get-ModulesWithDependency`,
+`Get-ModulesWithVersionSortedIdentityClient`, `Test-DPLibraryConflict`) are
+intentionally cross-edition — they scan the Windows PowerShell module roots too,
+so a Windows PowerShell 5.1 user can still discover which module to load first and
+apply the conflict workaround manually. See
+[docs/Architecture.md](docs/Architecture.md) §1.2 for the full platform-support
+contract.
+
 ## Purpose
 
 DLLPickle deliberately maintains current Microsoft authentication and identity
@@ -20,12 +31,32 @@ For usage guidance, see [README.md](README.md) and [docs/index.md](docs/index.md
 
 ## Dependency Management Strategy
 
-| Update Type | Policy | Automation |
-| ----------- | ------ | ---------- |
-| **Patch** (x.y.Z) | Auto-merge | Dependabot + auto-approve workflow |
-| **Minor** (x.Y.z) | Auto-merge | Dependabot + auto-approve workflow |
-| **Major** (X.y.z) | Manual review | Explicit maintainer approval |
-| **Upstream PowerShell module drift** | Candidate PR or issue | Upstream Compatibility workflow |
+Every tracked-dependency release is first checked for **target-framework
+alignment**: it must restore, build, and pass tests on `net8.0` under
+`--locked-mode`, and ship a net8.0-compatible assembly. Only then does the
+severity of the version jump decide how it ships:
+
+| Update Type | Policy |
+| ----------- | ------ |
+| **Patch / Minor** (x.Y.Z) | After the TFM-alignment + test gate, approve and merge with a detailed PR comment. Identity-library bumps are the module's core deliverable, so they ship as a **minor** module release (`feat:`). |
+| **Major** (X.y.z) | Still fully tested and TFM-verified, with the conflict surface re-adjudicated, but opened as a **draft PR with fully detailed notes** — **not** auto-merged and **not** auto-published. A maintainer promotes and merges it, publishing a **major** release (`breaking:`). |
+| **Upstream PowerShell module drift** | Candidate PR or issue after the scheduled inventory + drift check. |
+
+> **Publish note.** A merged dependency PR publishes a new gallery version only
+> when its commit also carries a release-worthy Conventional Commit prefix (see
+> Versioning, below). Dependabot's NuGet commits use the `deps:` prefix, which is
+> **not** a release prefix, so an auto-merged bump does not publish on its own —
+> land identity-library bumps as `feat:` (minor) or `breaking:` (major). The
+> major-version *draft-PR-with-detailed-notes* flow and an explicit TFM-inspection
+> check are intended contract that is not yet fully automated; see
+> [docs/Architecture.md](docs/Architecture.md) §8.2 and §10.
+
+The automation that supports this: Dependabot opens NuGet update PRs; the
+**Dependabot-Auto-Approve** workflow auto-approves and squash-merges patch/minor
+updates (restricted to the exact `DLLPickle.csproj` / `packages.lock.json`
+allow-list, and only after the `Build gate`, `Validate upstream compatibility
+tooling`, and `dependency-review` required checks pass) and excludes major
+updates from auto-merge.
 
 ## Versioning
 
@@ -46,6 +77,11 @@ detection of dependency or MSAL version changes. Label dependency-update PRs
 accordingly: the automated MSAL / identity-library bumps that are the module's
 core purpose should land as `feat:` so they produce a **minor** release, and a
 bundled-library **major** jump should be committed as a breaking change.
+Dependabot's NuGet PRs use the `deps:` prefix, which is **not** a release prefix,
+so this relabeling is a **manual step today** — a maintainer lands the squash
+commit as `feat:` / `breaking:`. See [docs/Architecture.md](docs/Architecture.md)
+§10 for the gap and the options to automate it (add `deps` to the recognized
+prefixes, or change the Dependabot commit prefix).
 
 A new PowerShell Gallery version is published **only** when a change affects the
 published module bundle (`src/DLLPickle/**` or the bundled package set). CI-,
@@ -57,7 +93,7 @@ docs-, policy-, and tooling-only changes do not trigger a release. See
 Dependabot tracks NuGet package releases, but DLLPickle also tracks the DLLs
 bundled by upstream PowerShell modules. The scheduled **Upstream Compatibility**
 workflow uses `build/dependency-policy.json` and tools under `tools/` to
-inventory latest PSGallery releases and propose safe exact-pin updates.
+inventory latest PSGallery releases and propose safe candidate pin updates.
 
 Monitored modules:
 
@@ -72,12 +108,15 @@ candidate generation, restore, build, and issue reproduction tests pass.
 
 ## NuGet Package Dependencies
 
+Version strategy in `DLLPickle.csproj` is **major-locked floating** (`N.*`); the
+lock file pins the concrete resolved version.
+
 | Package | Version Strategy | Notes |
 | ------- | ---------------- | ----- |
-| `Microsoft.Identity.Client` | Exact pin | Aligns base profile MSAL line |
-| `Microsoft.Identity.Client.Broker` | Exact pin | Kept aligned with MSAL |
-| `Microsoft.Identity.Client.Extensions.Msal` | Exact pin | Kept aligned with MSAL cache helper line |
-| `Microsoft.Identity.Client.NativeInterop` | Exact pin | Includes native runtime files |
+| `Microsoft.Identity.Client` | `4.*` (major-locked float) | Aligns base profile MSAL line |
+| `Microsoft.Identity.Client.Broker` | `4.*` (major-locked float) | Kept aligned with MSAL |
+| `Microsoft.Identity.Client.Extensions.Msal` | `4.*` (major-locked float) | Kept aligned with MSAL cache helper line |
+| `Microsoft.Identity.Client.NativeInterop` | `0.*` (major-locked float) | Includes native runtime files; tracks the broker requirement |
 | `Microsoft.IdentityModel.Abstractions` | `8.*` | Identity model support |
 | `Microsoft.IdentityModel.Logging` | `8.*` | Identity diagnostics/logging |
 | `Microsoft.IdentityModel.JsonWebTokens` | `8.*` | JWT handling |
@@ -97,13 +136,17 @@ their own code owners:
 - [Microsoft.IdentityModel.Tokens](https://www.nuget.org/packages/Microsoft.IdentityModel.Tokens)
 - [System.IdentityModel.Tokens.Jwt](https://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt)
 
-## Exact Pin Rationale
+## Version Pinning Rationale
 
-- Exact pins are used for the MSAL managed family (`Microsoft.Identity.Client`
-  and friends) because mixed-module sessions can fail when one module binds to a
-  lower, incompatible assembly.
-- Candidate exact-pin updates are generated from upstream module inventories and
-  still require full validation before publication.
+- The MSAL managed family (`Microsoft.Identity.Client` and friends) and the
+  IdentityModel family use **major-locked floating** references (`4.*`, `0.*`,
+  `8.*`) in `DLLPickle.csproj`: Dependabot can move the minor/patch within the
+  major, but a major jump is a deliberate, reviewed change.
+  `packages.lock.json` pins the **concrete resolved version**, so every build and
+  restore (`--locked-mode`) is reproducible. This matters because mixed-module
+  sessions can fail when one module binds to a lower, incompatible assembly.
+- Candidate pin updates are generated from upstream module inventories and still
+  require full validation before publication.
 - `Azure.Core` is intentionally **not** preloaded on the PowerShell 7.4+
   (net8.0) profile. Az.Accounts 5.x isolates its Azure SDK stack in a private
   `AssemblyLoadContext`; preloading `Azure.Core` into the default load context

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ For diagnostic detail, add `-ShowLoaderExceptions -Verbose`.
 - `Get-ModulesWithDependency` — list installed modules that package a given dependency.
 - `Get-ModulesWithVersionSortedIdentityClient` — compare modules by packaged `Microsoft.Identity.Client.dll` version.
 
+> The inspection helpers are **cross-edition**. `Import-DPLibrary` needs PowerShell 7.4+, but these helpers also scan the Windows PowerShell module roots — so a **Windows PowerShell 5.1** user can run them (from a PowerShell 7.4+ session) to find which module to load first and apply the "first one wins" fix manually.
+
 Full syntax and examples: [docs index](docs/index.md) · [command reference](docs/DLLPickle.md).
 
 ## 🥒 How It Works

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -7,7 +7,23 @@
 
 A single PowerShell process can load only one assembly of a given identity at a time. When several Microsoft service modules each bundle a different version of the same dependency DLL, the first one loaded "wins" and the others can fail with type-load or missing-method errors. DLLPickle **preloads a curated set of identity-stack assemblies into the default `AssemblyLoadContext` (ALC) before those modules load**, so default-ALC consumers share one coherent version.
 
-**Scope:** PowerShell 7.4+ on the `net8.0` runtime profile. Multi-TFM (net9.0/net10.0) is a deferred goal.
+### 1.1 Two tiers of functionality (and two different scopes)
+
+DLLPickle ships two distinct kinds of capability, and they have **different runtime requirements**. Keeping them separate is a load-bearing design decision — conflating them is the most common way to misread the platform-support contract.
+
+| Tier | Functions | Runtime requirement | What it does |
+| --- | --- | --- | --- |
+| **Preloader (automated fix)** | `Import-DPLibrary`, `Import-DPBaseProfile` | **PowerShell 7.4+ / .NET 8 (`net8.0`) only.** Depends on `AssemblyLoadContext`. | Loads the bundled `bin/net8.0` identity stack into the default ALC so later module loads reuse one coherent version. |
+| **Inspection / diagnostics (manual aid)** | `Find-DLLInPSModulePath`, `Get-ModuleImportCandidate`, `Get-ModulesWithDependency`, `Get-ModulesWithVersionSortedIdentityClient`, `Test-DPLibraryConflict` (plus `Get-DPConfig`/`Set-DPConfig`) | **Cross-edition by design.** Deliberately also scans Windows PowerShell module roots. | Reports which installed module ships the newest identity DLL, so a user can decide which service to connect to first. |
+
+The inspection tier exists to serve the project charter even for environments the preloader cannot reach: a **Windows PowerShell 5.1** user who hits the same version-conflict problem can run the inspection helpers to discover which module to load first and apply that **manual** "first-one-wins" workaround. See §1.2 for the precise platform-support contract.
+
+### 1.2 Platform-support contract (decisions 1 & 2)
+
+- **The automated preloader targets PowerShell 7.4+ on the `net8.0` runtime profile, and only that.** This is the supported way to *fix* the conflict automatically. It is enforced top to bottom: the manifest declares `PowerShellVersion = '7.4'` and `CompatiblePSEditions = @('Core')` (`src/DLLPickle/DLLPickle.psd1`); the build sets `RequiredPSVersion = '7.4.0'` (`build/DLLPickle.Settings.ps1`); the build project is single-target `<TargetFramework>net8.0</TargetFramework>` (`src/DLLPickle.Build/DLLPickle.csproj`); and `Import-DPLibrary` hard-codes `bin/net8.0` and throws if that directory is missing.
+- **Windows PowerShell 5.1 / .NET Framework 4.8 is not a supported runtime for the preloader, by design.** The whole self-isolation reasoning in §2 depends on `AssemblyLoadContext`, which does not exist on .NET Framework 4.8. The module manifest is `Core`-only, so DLLPickle is not intended to be *imported and run* under Windows PowerShell 5.1.
+- **The inspection/diagnostic tier is deliberately cross-edition.** Its functions are written to run on both editions and to scan the **Windows PowerShell module roots** (e.g. `Documents\WindowsPowerShell\Modules`) as well as the PowerShell 7 roots. This is intentional: a 5.1 user who needs a *manual* solution to the version-conflict problem can use these helpers to identify which module to connect to first. The supported way to do this today is to run the helpers **from a PowerShell 7.4+ session** while they inspect a machine's full set of installed modules (see the §10 note on the manifest edition declaration).
+- **Multi-TFM (net9.0/net10.0) is a deferred goal**, not current scope (§10). The methodology is TFM-parameterizable; the runtime profile is single-target `net8.0` today.
 
 ## 2. The runtime model that drives every decision (read this first)
 
@@ -30,7 +46,7 @@ They even run **different `Azure.Core` versions side-by-side** (Az `1.50`, Graph
 1. DLLPickle must **not** preload the Azure SDK stack. Preloading `Azure.Core` into the default ALC splits the identity of `Azure.Core.TokenRequestContext` across the module's private ALC boundary and breaks `Connect-AzAccount` with a `MissingMethodException` (shipped fix: 2.0.1).
 2. As more modules self-isolate, **DLLPickle's necessary scope shrinks** on PS 7.4+. Its remaining value is the **MSAL + IdentityModel** stack, which default-ALC consumers (Exchange Online, Teams) still share.
 
-> **Windows PowerShell 5.1 caveat — no ALC.** Everything above depends on `AssemblyLoadContext`, which exists only on .NET (Core) 5+. **Windows PowerShell 5.1 runs on .NET Framework 4.8, which has no ALC**, so modules **cannot** self-isolate there — every dependency lands in one shared load context. If net48 / WinPS 5.1 support is ever re-added, the "modules manage the Azure SDK themselves" premise does **not** hold, and the Azure SDK stack (`Azure.Core`, `Azure.Identity`, `Azure.Identity.Broker`, `System.ClientModel`) would need to be **preloaded again — conditionally, per-TFM (net48 only)** — exactly as #183 originally did before the 2.0 refactor over-generalized it. In other words: the `block` verdicts in §3 are correct **because** the runtime is ALC-capable; they are not universal. See §9 for the full re-introduction checklist.
+> **Windows PowerShell 5.1 caveat — no ALC.** Everything above depends on `AssemblyLoadContext`, which exists only on .NET (Core) 5+. **Windows PowerShell 5.1 runs on .NET Framework 4.8, which has no ALC**, so modules **cannot** self-isolate there — every dependency lands in one shared load context. This is *why* the preloader does not support 5.1 (§1.2): the "modules manage the Azure SDK themselves" premise does not hold. If net48 / WinPS 5.1 support is ever re-added, the Azure SDK stack (`Azure.Core`, `Azure.Identity`, `Azure.Identity.Broker`, `System.ClientModel`) would need to be **preloaded again — conditionally, per-TFM (net48 only)** — exactly as #183 originally did before the 2.0 refactor over-generalized it. In other words: the `block` verdicts in §3 are correct **because** the runtime is ALC-capable; they are not universal. See §10 for the full re-introduction checklist.
 
 ## 3. The preload decision model
 
@@ -49,7 +65,7 @@ Every tracked assembly is classified into exactly one of:
 | Assemblies | Class | Basis |
 | --- | --- | --- |
 | `Microsoft.Identity.Client` (+ `.Broker`, `.Extensions.Msal`, `.NativeInterop`); `Microsoft.IdentityModel.*`; `System.IdentityModel.Tokens.Jwt` | **preload** | Default-ALC consumers (EXO/Teams) + the #156 broker fix; 2.0.1-validated. |
-| `Azure.Core`, `Azure.Identity`, `Azure.Identity.Broker`, `System.ClientModel` | **block** | Az + Graph self-isolate these privately; preloading splits type identity (the `Connect-AzAccount` break). **ALC-capable runtimes only** — would flip to `preload` on net48 (see §2 caveat / §9). |
+| `Azure.Core`, `Azure.Identity`, `Azure.Identity.Broker`, `System.ClientModel` | **block** | Az + Graph self-isolate these privately; preloading splits type identity (the `Connect-AzAccount` break). **ALC-capable runtimes only** — would flip to `preload` on net48 (see §2 caveat / §10). |
 | `Microsoft.OData.Core`, `Microsoft.OData.Edm`, `Microsoft.Spatial` | **block** (report-only) | #174 — preloading breaks Az.Storage. |
 | `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions` | **block** | #193 — incidental `Microsoft.IdentityModel.Tokens` transitives, not host-provided. Preloading DLLPickle's own copies into the default ALC collided with the copies `Az.Resources` bundles (`assembly with same name is already loaded`). Excluded via `ExcludeAssets="runtime"` (shipped 2.0.2); `Microsoft.IdentityModel.Tokens` still loads without them. |
 
@@ -63,7 +79,8 @@ Every tracked assembly is classified into exactly one of:
 | Dependency policy | `build/dependency-policy.json` | **Decision source of truth** — per-assembly classification + evidence, monitored modules, target scenario, drift baseline. |
 | Analysis tools | `tools/Get-DLLPickleLoadedTrackedAssembly.ps1`, `New-DLLPickleConflictMatrix.ps1`, `Compare-DLLPickleConflictMatrix.ps1`, `Get-DLLPickleRuntimeAssemblySnapshot.ps1`, `Get-DLLPickleUpstreamInventory.ps1`, `Update-DLLPickleDependencyPins.ps1` | Inventory upstream modules, build the conflict matrix, probe runtime ALC ownership (filter sourced from `trackedAssemblies`), detect drift, and apply policy pins. |
 | Build script | `build/DLLPickle.Build.ps1` | Invoke-Build tasks: Analyze, AnalyzeTests, AnalyzeTools, Test, RestoreDependencies, PrepareModuleOutput, IntegrationTest. |
-| CI | `.github/workflows/` | Build/test matrix, Upstream-Compatibility (inventory + drift), Dependabot auto-approve, tag-driven Release-and-Publish. |
+| Release scripts | `.github/ci-scripts/Get-VersionBump.ps1` | Decides the semantic-version bump (and whether to release at all) from Conventional Commit prefixes since the last tag. The publish-decision logic behind §8.1. |
+| CI | `.github/workflows/` | Build/test matrix, Upstream-Compatibility (inventory + drift), Dependabot auto-approve, path+commit-gated `Release-and-Publish`. |
 | Build output | `module/DLLPickle/` | **Generated** (gitignored). Rebuilt by `PrepareModuleOutput`; never hand-edited. |
 
 ## 5. Source-of-truth map
@@ -73,6 +90,9 @@ Every tracked assembly is classified into exactly one of:
 | Which assemblies are preloaded/blocked, and why? | `build/dependency-policy.json` (classification + evidence) |
 | What is actually bundled? | `src/DLLPickle.Build/DLLPickle.csproj` (+ `packages.lock.json`) — must match the policy's `preload` set |
 | How does the loader behave? | `src/DLLPickle/Public/Import-DPLibrary.ps1` |
+| Which runtime/edition is supported? | §1.2 (platform-support contract) + `src/DLLPickle/DLLPickle.psd1` |
+| When does a merged PR publish a new version? | §8.1 + `.github/workflows/Release-and-Publish.yml` + `.github/ci-scripts/Get-VersionBump.ps1` |
+| How is a dependency update adjudicated and shipped? | §8.2 + `build/dependency-policy.json` + `.github/workflows/Dependabot-Auto-Approve.yml` |
 | User guidance | `docs/Deep-Dive.md` |
 | Dependency/update policy | `DEPENDENCIES.md`, `.github/dependabot.yml` |
 | Design rationale (point-in-time) | `docs/superpowers/specs/2026-05-31-dll-needs-analysis-design.md` |
@@ -93,10 +113,52 @@ Every tracked assembly is classified into exactly one of:
 - **Issue reproduction + composition:** `Invoke-Build -Task IssueReproTest` (synthetic modules; deterministic).
 - **Runtime adjudication — non-auth tier (CI-capable):** strict per-module ALC snapshots (module/probe failures are fatal) + the four-module import/composition smoke.
 - **Runtime adjudication — auth tier (maintainer-run; future Stage 2b automatable via GitHub OIDC + Entra federated credential):** real `Connect-*` to a dev tenant. This is the sign-off for any change to the bundled set.
-- **Publish trigger:** `Release-and-Publish` auto-runs **only on bundle-affecting paths** (`src/DLLPickle/**`, `src/DLLPickle.Build/DLLPickle.csproj`, `src/DLLPickle.Build/packages.lock.json`). CI-, policy-, docs-, test-, and tooling-only changes do **not** publish a new gallery version; `workflow_dispatch` is the deliberate-release escape hatch.
-- **Dependency PRs (Dependabot):** the bumped *bundle* is validated by **Build Module** (full build under `--locked-mode` + the #193/Azure.Core repro guards), bounded by the csproj floating-with-cap constraints. The Upstream-Compatibility `pr-smoke` adds an **upstream conflict-surface freshness check** — explicitly *not* a bundle validation, since a self-bump does not move the upstream fingerprint. **Enforcement caveat:** these signals only block `gh pr merge --auto` if the build + Dependency Review checks are configured as **required status checks** (see §9).
+- **Publish trigger:** `Release-and-Publish` publishes a merged PR only when it passes **both** the bundle-affecting **path gate** and the Conventional-Commit **version gate** — see §8.1 for the full contract (including the `deps:`-prefix caveat). CI-, policy-, docs-, test-, and tooling-only changes do **not** publish a new gallery version; `workflow_dispatch` is the deliberate-release escape hatch.
+- **Dependency PRs (Dependabot):** the bumped *bundle* is validated by **Build Module** (full build under `--locked-mode` + the #193/Azure.Core repro guards), bounded by the csproj floating-with-cap constraints. The Upstream-Compatibility `pr-smoke` adds an **upstream conflict-surface freshness check** — explicitly *not* a bundle validation, since a self-bump does not move the upstream fingerprint. See §8.2 for the full dependency lifecycle and §10 for the `deps:`-prefix publish gap. **Enforcement caveat:** these signals only block `gh pr merge --auto` if the build + Dependency Review checks are configured as **required status checks** (see §10).
 
-## 8. Agent workstream conventions
+## 8. Release & dependency-update contract
+
+This section is the source of truth for **when a merged change publishes a new PowerShell Gallery version** (decision 3) and **how a tracked-dependency release is adjudicated, tested, and shipped** (decision 4). It documents the **intended contract**; where today's automation does not yet fully implement it, the delta is recorded in §10. No behavior here is changed by simply updating this document.
+
+### 8.1 What publishes a new version (decision 3)
+
+The published artifact is the **module bundle**: the module source under `src/DLLPickle/**` and the bundled DLL set realized by `src/DLLPickle.Build/DLLPickle.csproj` + `packages.lock.json`. A change that alters that bundle should produce a new gallery version; CI-, policy-, docs-, test-, and tooling-only changes should not.
+
+`Release-and-Publish` auto-publishes a merged PR **only when both gates pass**:
+
+1. **Path gate** — the merge touches a bundle-affecting path: `src/DLLPickle/**`, `src/DLLPickle.Build/DLLPickle.csproj`, or `src/DLLPickle.Build/packages.lock.json` (the workflow `paths:` filter).
+2. **Version gate** — `.github/ci-scripts/Get-VersionBump.ps1` finds a release-worthy Conventional Commit prefix among the commits since the last tag. Recognized prefixes:
+
+   | Bump | Prefixes |
+   | --- | --- |
+   | **major** | `BREAKING CHANGE:`, `breaking:`, `major-release` |
+   | **minor** | `feat:`, `minor:` |
+   | **patch** | `fix:`, `perf:`, `refactor:`, `security:`, `chore:` |
+
+   Any other prefix (`docs:`, `style:`, `ci:`, **`deps:`**, …) yields `ShouldRelease = false` → **no publish**.
+
+Versioning is **tag-driven**: the in-source manifest stays at the `0.0.0` placeholder, the Git tag `vX.Y.Z` is the source of truth, and the real version is stamped into the built artifact at publish time. A failed publish rolls back by deleting the tag and release; `main` is never committed to. `workflow_dispatch` is the deliberate-release escape hatch (e.g. to ship a packaging-logic change that does not move a bundle path).
+
+> **Both gates matter for dependency PRs.** A Dependabot NuGet bump touches `DLLPickle.csproj` + `packages.lock.json` (path gate ✔) but its default commit prefix is `deps:` — **not** a recognized release prefix — so on its own it does **not** publish. Closing that gap is the subject of §8.2 and the recorded gap in §10.
+
+### 8.2 Tracked-dependency release lifecycle (decision 4)
+
+A "tracked dependency" is one of the NuGet packages bundled into the preload set (the MSAL + IdentityModel families in `DLLPickle.csproj`; see §3). When a new release of one is detected — by Dependabot or the scheduled Upstream-Compatibility candidate flow — it is adjudicated by the **severity of the version jump**.
+
+**Step 0 — TFM-alignment check (precondition for both paths).** Before any merge, confirm the new release aligns with the supported target framework moniker(s). "TFM-aligned" means **both**:
+
+- **(a) Build-gate proof** — the project still restores under `--locked-mode` and builds + passes Pester/CI green on `net8.0` (the `Build gate` required check); **and**
+- **(b) Explicit TFM inspection** — the package actually ships an assembly compatible with the supported TFM(s) (`net8.0`, or a `netstandard2.0` asset that loads on net8.0), rather than appearing to work only by luck of transitive resolution.
+
+A release that fails either half is not TFM-aligned and must not be merged on the automated path.
+
+**Minor / patch release** → run Step 0 (TFM alignment) + Pester + CI, then **approve and merge with a detailed PR comment** recording what moved, the alignment evidence, and the conflict-surface result. Because identity-library bumps are the module's core deliverable, a minor/patch dependency bump is intended to produce a **minor** module release; to fire the version gate (§8.1) the merge must carry a `feat:` prefix (see the §10 `deps:`-prefix gap).
+
+**Major release** → still **fully tested** (Pester + CI) and **verified for architecture alignment** (Step 0, plus a re-adjudication of the §3 preload/block classifications, since a major upstream jump can move the conflict surface), **but it lands as a draft PR with fully detailed notes** — never auto-merged and never auto-published. The notes should cover: the version delta and an upstream changelog / breaking-change summary, the TFM-alignment result, the Pester/CI outcome, and the conflict-surface / `dependency-policy.json` impact. A maintainer promotes the draft to ready and merges after review; the merge then publishes a **major** module release (carried as `breaking:`).
+
+This mirrors the **hard gate** in §9: bundle-set changes are behavior-changing and require the auth-tier real-environment sign-off; they are not auto-merged blindly.
+
+## 9. Agent workstream conventions
 
 When changing the preload contract, follow this loop:
 
@@ -119,16 +181,20 @@ Issue #239 was adjudicated on 2026-06-20 against Microsoft.Graph.Authentication 
 - Commit/push only when the maintainer asks.
 - Never hand-edit `module/` (generated). Never weaken analyzer settings to silence a finding — fix the code or scope a justified suppression.
 
-## 9. Known gaps / follow-ups
+## 10. Known gaps / follow-ups
 
 - **Required status checks.** The "Protect Main" ruleset enforces a PR (with review-thread resolution), Copilot review, code quality, and three required status checks: **`Build gate`**, **`Validate upstream compatibility tooling`**, and **`dependency-review`**. `Validate upstream compatibility tooling` is the always-reported aggregate over changed-file detection and the conditional Windows validation worker; policy, dependency, and fingerprint-generator changes also run a fresh live inventory. Keep the workflows triggered on every PR and condition jobs internally—workflow-level path filters can leave required checks pending. Dependabot auto-merge is restricted to the exact csproj/lock-file allow-list and waits on all three contexts.
+- **Dependency bumps do not publish on their own — the `deps:` prefix gap (decisions 3 & 4).** Dependabot's NuGet `commit-message.prefix` is `deps` (`.github/dependabot.yml`), which `Get-VersionBump.ps1` does **not** recognize as a release prefix (§8.1). So an auto-approved, squash-merged minor/patch dependency bump satisfies the *path* gate but yields `ShouldRelease = false` and **does not publish**. Until the contract is realized in code, a maintainer must land the bump under a recognized prefix — `feat:` for the intended **minor** release (decision 4) or `breaking:` for a major. Options to close it: add `deps` to the recognized minor prefixes in `Get-VersionBump.ps1`, or change the Dependabot `commit-message.prefix` to `feat`. (Documented as the contract here; **no code change made in this revision**.)
+- **Major-dependency draft-PR flow is not implemented (decision 4).** `Dependabot-Auto-Approve.yml` correctly excludes `version-update:semver-major` PRs from `gh pr merge --auto` and posts a single generic "requires manual review" comment, but it does **not** convert them to draft or attach the fully detailed, structured notes §8.2 specifies (version delta, upstream breaking-change summary, TFM-alignment result, Pester/CI outcome, conflict-surface impact). The auto-merge split is enforced; the draft + detailed-notes half is manual today.
+- **Explicit TFM-alignment inspection is not automated (decision 4).** `Get-DLLPickleUpstreamInventory.ps1` captures only assembly `Name`/`Version`/`FullName`; it does not extract or assert a target framework. Step 0(a) of §8.2 (the `Build gate`) is enforced, so a TFM-incompatible package would fail the build — but Step 0(b), the dedicated net8.0/netstandard2.0 compatibility assertion, is satisfied only implicitly by a green build, not by a purpose-built check.
+- **Platform-support contract vs. manifest edition (decision 2).** The inspection/diagnostic tier is intended to be cross-edition (§1.2), but the manifest declares `CompatiblePSEditions = @('Core')`, so *importing* the module under Windows PowerShell 5.1 surfaces a compatibility warning. The supported manual-remediation path is therefore to run the inspection helpers **from a PowerShell 7.4+ session** while they scan the Windows PowerShell module roots — not to import DLLPickle under 5.1. Two code paths back this cross-edition intent on purpose: `Set-DPConfig` keeps a `$PSEdition`-aware encoding fallback, and `Find-DLLInPSModulePath` seeds the `WindowsPowerShell\Modules` roots (the all-users WinPS root only when actually running on 5.1). These are intentional, not residual dead code; recorded here so the contract is explicit.
 - **`Az.Resources` is not in `monitoredModules`.** It is the observed #193 collision source, but its copy and future drift are **not** inventoried. Among monitored modules the `Microsoft.Extensions.*` transitives are observed only in `MicrosoftTeams` (a single shipper → not in the conflict surface), recorded as `trackingScope` on the blocked entries. Note #193 was a *bundle-vs-consumer* collision (DLLPickle's preloaded copy vs Az.Resources'), which the cross-module drift gate does not model — the regression guard is the integration test that keeps these transitives out of `bin`, not the matrix. Re-adjudicate manually if an Az.Resources change is suspected, or add it to `monitoredModules` to track it directly.
 - **EXO/Teams ALC ownership** is not yet captured — a bare `Import-Module` doesn't eager-load their identity assemblies; the probe needs a representative `-ProbeCommand`.
-- **Multi-TFM (net9.0/net10.0):** deferred; the methodology is TFM-parameterizable. net9.0/net10.0 are ALC-capable, so the `block` verdicts in §3 carry over to them. The `net8.0` bundle is confirmed to load on **PS 7.6 / .NET 10 via roll-forward** (Az.Resources import verified, no #193 regression) — a positive signal that multi-TFM is mostly a packaging exercise, not a behavioral one, on ALC-capable runtimes.
+- **Multi-TFM (net9.0/net10.0):** deferred; the methodology is TFM-parameterizable. net9.0/net10.0 are ALC-capable, so the `block` verdicts in §3 carry over to them. The `net8.0` bundle is confirmed to load on **PS 7.6 / .NET 10 via roll-forward** (Az.Resources import verified, no #193 regression) — a positive signal that multi-TFM is mostly a packaging exercise, not a behavioral one, on ALC-capable runtimes. When it lands, `dependency-policy.json` preload entries (currently a single `targetFramework: net8.0` each) and the `Update-DLLPickleDependencyPins` tooling will need a per-TFM representation; the `RestoreDependencies` task already parses both `TargetFramework` and `TargetFrameworks` in anticipation.
 - **Re-introducing Windows PowerShell 5.1 / net48 (no ALC) — checklist if attempted:** because net48 has no `AssemblyLoadContext`, modules cannot self-isolate and the §3 `block` verdicts for the Azure SDK stack **invert**. Re-support would require: (1) multi-targeting the build to `net48` alongside `net8.0`; (2) **conditionally preloading the Azure SDK stack** (`Azure.Core` + `Azure.Identity`/`Broker` + `System.ClientModel`) for net48 only — pinned to the highest version the WinPS-supported module set agrees on, as #183 did; (3) restoring net48-specific dependency conditions in `DLLPickle.csproj` (e.g. `Condition="'$(TargetFramework)' == 'net48'"`); (4) restoring `CompatiblePSEditions = @('Core','Desktop')` and lowering the manifest `PowerShellVersion`, plus per-edition guards in `Import-DPLibrary`; (5) adding WinPS 5.1 to the CI test matrix and re-validating the #156/#165-class scenarios. The 2.0 refactor's mistake was applying the net48-era Azure.Core preload to net8 unconditionally — any re-introduction must keep it **strictly TFM-conditional**.
-- **Planned feature enhancements (backlog).** Forward-looking ideas consolidated from the former root `Roadmap.md`; not yet scheduled, order is not guaranteed, and large dependency/platform shifts may change priority. (Released and in-progress work lives in [CHANGELOG.md](../CHANGELOG.md) — for example the `Microsoft.PowerShell.PlatyPS` help-generation migration is already tracked there, and the broader PowerShell 7.4+ compatibility and supply-chain hardening work is the ongoing subject of §3 and §8.)
+- **Planned feature enhancements (backlog).** Forward-looking ideas consolidated from the former root `Roadmap.md`; not yet scheduled, order is not guaranteed, and large dependency/platform shifts may change priority. (Released and in-progress work lives in [CHANGELOG.md](../CHANGELOG.md) — for example the `Microsoft.PowerShell.PlatyPS` help-generation migration is already tracked there, and the broader PowerShell 7.4+ compatibility and supply-chain hardening work is the ongoing subject of §3, §8, and §9.)
   - Import a specific version of MSAL (`Microsoft.Identity.Client`) on demand, rather than only the bundled pin.
-  - Verify a package's hash/signature against the original source (e.g. NuGet) metadata before preload — a supply-chain integrity check extending the §8 dependency work.
+  - Verify a package's hash/signature against the original source (e.g. NuGet) metadata before preload — a supply-chain integrity check extending the dependency-update work in §8.
   - Option to preload additional common (non-identity) assemblies beyond the default identity stack.
   - Option to inspect and preload only the newest version of relevant assemblies already present among the modules installed on the current system. The inspection side already exists (`Get-ModuleImportCandidate`, `Get-ModulesWithVersionSortedIdentityClient`, `Find-DLLInPSModulePath`); this would add the preload-from-installed mode.
   - A function to import a specific named set of assemblies — a targeted alternative to the full `Import-DPLibrary` set or `Import-DPBaseProfile`.

--- a/docs/Deep-Dive.md
+++ b/docs/Deep-Dive.md
@@ -50,6 +50,29 @@ To improve reliability, the loader:
 This approach reduces transient first-pass load failures while keeping behavior
 predictable and diagnosable.
 
+## The inspection helpers (and Windows PowerShell 5.1)
+
+`Import-DPLibrary` is the *automated* fix, and it needs PowerShell 7.4+ / .NET 8
+because it depends on `AssemblyLoadContext`. But DLLPickle also ships a set of
+**inspection helpers** that are deliberately cross-edition:
+
+- `Find-DLLInPSModulePath` — find DLLs across the installed module paths
+  (including the Windows PowerShell roots), filtered by product metadata.
+- `Get-ModulesWithDependency` — list installed modules that package a given
+  dependency DLL.
+- `Get-ModulesWithVersionSortedIdentityClient` — compare modules by the
+  `Microsoft.Identity.Client.dll` version they ship.
+- `Get-ModuleImportCandidate` — show which installed module version would import.
+- `Test-DPLibraryConflict` — report known-incompatible module pairs already loaded
+  in the current session.
+
+These exist so the project charter still helps environments the preloader cannot
+reach. A **Windows PowerShell 5.1** user who hits the same DLL conflict can run
+these helpers from a PowerShell 7.4+ session, see which installed module ships the
+newest identity DLL, and connect to that service *first* — the same "first one
+wins" idea, applied by hand. The automated preload is the convenience; the manual
+workaround is always available.
+
 ## Dependency Maintenance Automation
 
 DLLPickle's preload set must track both NuGet package releases and the DLLs that
@@ -62,11 +85,11 @@ The repository therefore includes an upstream compatibility policy and scheduled
 workflow:
 
 - `build/dependency-policy.json` declares monitored PSGallery modules, tracked
-  assembly families, exact pins, and blocked preload families.
+  assembly families, per-assembly version policies, and blocked preload families.
 - `tools/Get-DLLPickleUpstreamInventory.ps1` downloads and inventories the
   latest monitored modules.
 - `tools/Update-DLLPickleDependencyPins.ps1` compares the inventory with the
-  policy and applies safe candidate exact-pin updates.
+  policy and applies safe candidate pin updates (major-locked floating `N.*`, or an exact pin when a `maximumPackageVersion` cap applies).
 - `.github/workflows/Upstream-Compatibility.yml` runs the inventory and
   candidate update flow on a schedule or on demand.
 
@@ -99,10 +122,12 @@ preload is unnecessary on .NET 8.
 
 > **Windows PowerShell 5.1 caveat:** this module self-isolation relies on
 > `AssemblyLoadContext`, which only exists on .NET (Core) 5+. Windows PowerShell
-> 5.1 (.NET Framework 4.8) has no ALC, so modules cannot self-isolate there. If
-> net48 support is ever re-added, the Azure SDK stack would need to be preloaded
-> again for that target — see the re-introduction checklist in
-> [Architecture.md](Architecture.md).
+> 5.1 (.NET Framework 4.8) has no ALC, so modules cannot self-isolate there —
+> which is exactly why DLLPickle's automated preloader does not support 5.1 (use
+> the inspection helpers above for the manual path). Re-adding net48 is **out of
+> scope for the current major version**; if it were ever revisited, the Azure SDK
+> stack would have to be preloaded again, net48-only. The maintainer-facing
+> re-introduction checklist lives in [Architecture.md](Architecture.md) §10.
 
 ## Validated Base Profile
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -18,6 +18,27 @@ repeatable diagnostics when Microsoft service modules load conflicting
 assemblies. The default tests use synthetic modules and do not require service
 credentials, VS Code, Azure Automation, or PSGallery module installation.
 
+## Supported runtime (and Windows PowerShell 5.1)
+
+The automated fix — `Import-DPLibrary` and `Import-DPBaseProfile` — requires
+**PowerShell 7.4+ on .NET 8**. It relies on `AssemblyLoadContext`, which does not
+exist on .NET Framework 4.8, so it does not run on **Windows PowerShell 5.1**.
+
+If you are on Windows PowerShell 5.1 and hitting the same conflict, you can still
+use DLLPickle's **inspection helpers** to solve it manually. Run them from a
+PowerShell 7.4+ session — they scan the Windows PowerShell module roots too — to
+find which installed module ships the newest identity DLL, then connect to that
+service *first* (the "first one wins" workaround). For example:
+
+```powershell
+# Compare installed modules by the Microsoft.Identity.Client version they ship,
+# and see which copy would load first.
+Get-ModulesWithVersionSortedIdentityClient
+Get-ModuleImportCandidate
+```
+
+See [Architecture.md](Architecture.md) §1.2 for the full platform-support contract.
+
 ## Run the safe issue repro tests
 
 The safe repro task prepares the built module output and runs integration tests
@@ -64,6 +85,32 @@ Compare-DLLPickleScenarioResult -BaselinePath .\before.json -CandidatePath .\aft
 
 The comparison shows changed step outcomes and final loaded assembly
 differences by name, version, and location.
+
+## Common loader errors
+
+### `Binary directory not found for target framework 'net8.0'`
+
+`Import-DPLibrary` loads the bundled assemblies from the module's `bin/net8.0`
+folder and throws this error if that folder is missing:
+
+```text
+Binary directory not found for target framework 'net8.0' at: <path>\bin\net8.0
+```
+
+This usually means the installed module is incomplete, or you are importing from a
+source tree that has not been built (the `bin/net8.0` output is generated, not
+committed). Re-install the module from the PowerShell Gallery:
+
+```powershell
+Install-PSResource -Name DLLPickle   # or: Install-Module DLLPickle -Scope CurrentUser
+```
+
+If you are working from a clone, build the module output first and import that:
+
+```powershell
+Invoke-Build -Task Build -File .\build\DLLPickle.Build.ps1
+Import-Module .\module\DLLPickle\DLLPickle.psd1
+```
 
 ## Current issue-specific findings
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,11 @@ For more information about how this works, [read here](https://raw.githubusercon
 
 ### Prerequisites
 
-PowerShell 7.4 or later on Linux, macOS, or Windows.
+PowerShell 7.4 or later on Linux, macOS, or Windows for the automated preload
+(`Import-DPLibrary`). The inspection helpers — for diagnosing conflicts and
+guiding a manual fix, including across Windows PowerShell 5.1 module installs —
+are cross-edition. See the [Deep Dive](Deep-Dive.md) and
+[Architecture](Architecture.md) for the full platform-support contract.
 
 ### Installation
 


### PR DESCRIPTION
## Summary

A documentation refresh anchored on DLLPickle's four primary design decisions, plus a `.gitattributes` to stop future line-ending churn. **Docs-only — no module code, build, or workflow behavior changed.** This PR touches no bundle-affecting path, so it does not (and should not) trigger a Gallery release.

### The four design decisions, now documented as the contract

1. **Target PowerShell 7.4 / .NET 8 (`net8.0`)** — formalized in `Architecture.md` §1.2.
2. **No Windows PowerShell 5.1 for the automated preloader** — but with an important clarification (below).
3. **Publish-on-merge for bundle changes** — documented precisely in the new `Architecture.md` §8.1.
4. **Dependency-update lifecycle** (minor→merge+publish, major→draft PR) — documented in §8.2 and `DEPENDENCIES.md`.

### Two-tier platform-support contract (the key clarification)

The refresh makes explicit that DLLPickle has **two tiers** with different runtime requirements:

- **Preloader** (`Import-DPLibrary` / `Import-DPBaseProfile`) — PowerShell 7.4+ / .NET 8 only (needs `AssemblyLoadContext`).
- **Inspection/diagnostics** (`Find-DLLInPSModulePath`, `Get-ModuleImportCandidate`, `Get-ModulesWithDependency`, `Get-ModulesWithVersionSortedIdentityClient`, `Test-DPLibraryConflict`) — **cross-edition by design**, so a Windows PowerShell 5.1 user can still diagnose the conflict and apply the "first one wins" fix manually.

### Honest gap recording (not fixes)

During review I verified that decisions 3 & 4 are not fully implemented yet, and recorded the gaps in `Architecture.md` §10 rather than papering over them:

- **`deps:` prefix gap** — `Release-and-Publish` requires both a bundle-path change **and** a release-worthy Conventional Commit prefix (`Get-VersionBump.ps1`). Dependabot's `deps:` prefix isn't recognized, so an auto-merged dependency bump **does not publish on its own** today.
- **Major-dependency draft-PR flow** — not implemented; major bumps only get a generic "requires manual review" comment.
- **Explicit TFM-alignment check** — `Get-DLLPickleUpstreamInventory.ps1` never inspects a target framework; only the Build gate proves compatibility today.

A follow-up implementation prompt for these gaps is being prepared separately.

### `.gitattributes`

`*.md text eol=crlf` so future markdown edits don't produce spurious CRLF/LF churn (this repo currently has mixed endings and no `.gitattributes`). Kept as its own commit; existing files are **not** mass-renormalized here — that would churn ~30 unrelated `.md` files and defeat the purpose of a reviewable PR. They normalize as they're next edited.

## Commits

1. `docs:` — content changes (content-only diff; verify with "hide whitespace").
2. `chore:` — add `.gitattributes`.

## Files

`docs/Architecture.md`, `DEPENDENCIES.md`, `docs/Troubleshooting.md`, `docs/Deep-Dive.md`, `README.md`, `docs/index.md`, `CHANGELOG.md`, `.gitattributes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
