### PR TITLE
[codex] Add tracked gap register

### DIFF
--- a/.github/prompts/maintain-gap.prompt.md
+++ b/.github/prompts/maintain-gap.prompt.md
@@ -25,7 +25,7 @@ Gap file path: `${input:gapFile:docs/gaps/GAP-001-dependency-policy-realization-
 
 1. Read the requested gap file.
 2. Read `docs/gaps/README.md`.
-3. Read every file listed in the gap file's `related_docs` frontmatter.
+3. Read every path listed in the gap file's `related_docs` frontmatter (if an entry is a directory, read the `*.md` files under it).
 4. Search the repository for the gap ID.
 5. Determine whether the gap is still `open`, `in-progress`, `blocked`, `resolved`, `superseded`, or `wont-fix`.
 6. If implementing a fix:

--- a/.github/prompts/maintain-gap.prompt.md
+++ b/.github/prompts/maintain-gap.prompt.md
@@ -1,0 +1,67 @@
+---
+description: 'Resolve or update a DLLPickle gap register item.'
+mode: 'agent'
+tools: ['codebase', 'editFiles', 'terminal']
+---
+
+# Maintain DLLPickle Gap
+
+## Mission
+
+Resolve, update, block, supersede, or intentionally accept one gap from `docs/gaps/`.
+
+## Required input
+
+Gap file path: `${input:gapFile:docs/gaps/GAP-001-dependency-policy-realization-guard.md}`
+
+## Scope and preconditions
+
+- Work only on the requested gap unless another gap must be updated because of the same change.
+- Do not mark a gap `resolved` unless every acceptance criterion in the gap file is complete or explicitly superseded.
+- Do not hide unresolved work by deleting acceptance criteria.
+- If the implementation changes architecture, invariants, validation gates, source-of-truth mappings, release behavior, or user-facing behavior, update the related documentation in the same PR.
+
+## Workflow
+
+1. Read the requested gap file.
+2. Read `docs/gaps/README.md`.
+3. Read every file listed in the gap file's `related_docs` frontmatter.
+4. Search the repository for the gap ID.
+5. Determine whether the gap is still `open`, `in-progress`, `blocked`, `resolved`, `superseded`, or `wont-fix`.
+6. If implementing a fix:
+   - make the smallest safe source, workflow, policy, test, or documentation change;
+   - add or update automated guards when practical;
+   - run the relevant validation commands;
+   - capture any validation that cannot be run and why.
+7. Before finishing, update:
+   - the gap file frontmatter,
+   - the gap file checklist,
+   - `docs/gaps/README.md`,
+   - `docs/Architecture.md` if architecture, invariants, validation gates, source-of-truth mappings, or known gaps changed,
+   - any related `docs/superpowers/plans/*` or `docs/superpowers/specs/*` file when the plan/spec is stale, superseded, or completed.
+
+## Resolution rules
+
+- Use `status: resolved` only when the implementation, tests, and documentation updates are complete and the resolving PR is linked.
+- Use `status: in-progress` when an implementation PR exists but has not merged.
+- Use `status: blocked` when a decision, credential, tenant, environment, external ruleset, or upstream dependency prevents safe completion.
+- Use `status: superseded` when a newer design or decision makes the gap obsolete. Explain the superseding reference in `Resolution notes`.
+- Use `status: wont-fix` only when the maintainer intentionally accepts the gap and the rationale is documented.
+
+## Output expectations
+
+Summarize:
+
+- status before and after,
+- files changed,
+- tests or checks run,
+- documentation updated,
+- remaining caveats.
+
+## Quality checks
+
+- [ ] The gap file status and checklist match the actual changes.
+- [ ] `docs/gaps/README.md` matches the gap file frontmatter.
+- [ ] Related docs are updated or explicitly left unchanged with rationale.
+- [ ] Relevant tests were added or updated when practical.
+- [ ] Validation commands were run or a clear blocker is documented.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD013 MD024 -->
 # DLLPickle Architecture Blueprint
 
-> **Audience:** maintainers and **agentic workstreams**. This is the durable, living source of truth for how DLLPickle is built and why. Read it before changing the preload contract; update it after. For the point-in-time design rationale, see [the needs-analysis design spec](superpowers/specs/2026-05-31-dll-needs-analysis-design.md). For user-facing guidance, see [Deep-Dive.md](Deep-Dive.md) and [DEPENDENCIES.md](DEPENDENCIES.md).
+> **Audience:** maintainers and **agentic workstreams**. This is the durable, living source of truth for how DLLPickle is built and why. Read it before changing the preload contract; update it after. For the point-in-time design rationale, see [the needs-analysis design spec](superpowers/specs/2026-05-31-dll-needs-analysis-design.md). For user-facing guidance, see [Deep-Dive.md](Deep-Dive.md) and [DEPENDENCIES.md](DEPENDENCIES.md). Open maintenance traps and follow-ups are tracked in the [gap register](gaps/README.md).
 
 ## 1. What DLLPickle does
 
@@ -82,6 +82,7 @@ Every tracked assembly is classified into exactly one of:
 | Release scripts | `.github/ci-scripts/Get-VersionBump.ps1` | Decides the semantic-version bump (and whether to release at all) from Conventional Commit prefixes since the last tag. The publish-decision logic behind §8.1. |
 | CI | `.github/workflows/` | Build/test matrix, Upstream-Compatibility (inventory + drift), Dependabot auto-approve, path+commit-gated `Release-and-Publish`. |
 | Build output | `module/DLLPickle/` | **Generated** (gitignored). Rebuilt by `PrepareModuleOutput`; never hand-edited. |
+| Gap register | `docs/gaps/` | Repo-local status tracking for maintenance traps, automation gaps, deferred follow-ups, and agent-resolvable work items. |
 
 ## 5. Source-of-truth map
 
@@ -93,6 +94,7 @@ Every tracked assembly is classified into exactly one of:
 | Which runtime/edition is supported? | §1.2 (platform-support contract) + `src/DLLPickle/DLLPickle.psd1` |
 | When does a merged PR publish a new version? | §8.1 + `.github/workflows/Release-and-Publish.yml` + `.github/ci-scripts/Get-VersionBump.ps1` |
 | How is a dependency update adjudicated and shipped? | §8.2 + `build/dependency-policy.json` + `.github/workflows/Dependabot-Auto-Approve.yml` |
+| What maintenance traps and follow-up gaps remain? | `docs/gaps/README.md` and the individual `docs/gaps/GAP-*.md` files |
 | User guidance | `docs/Deep-Dive.md` |
 | Dependency/update policy | `docs/DEPENDENCIES.md`, `.github/dependabot.yml` |
 | Design rationale (point-in-time) | `docs/superpowers/specs/2026-05-31-dll-needs-analysis-design.md` |
@@ -102,7 +104,7 @@ Every tracked assembly is classified into exactly one of:
 
 - **No `block` assembly appears in `module/DLLPickle/bin/net8.0`.** → `tests/Integration/DLLPickle.IntegrationTest.Tests.ps1` (Azure.Core guard + the #193 `Microsoft.Extensions.*` guard; extend per newly-blocked assembly).
 - **No preloaded assembly is loaded into two ALCs at once** in the four-module scenario. → integration ALC-split guard (runtime tier; maintainer-run with real modules).
-- **The bundled `preload` set equals `dependency-policy.json`'s `preload` entries.** → planned realization guard (Task A6); until then, verified by review.
+- **The bundled `preload` set equals `dependency-policy.json`'s `preload` entries.** → `tests/Integration/DependencyPolicyRealization.Tests.ps1` after GAP-001 / PR #257 merges; until then, verified by review.
 - **Runtime-provided BCL assemblies (e.g. `System.Text.Json`) are never preloaded.** → conflict-matrix `AlcOwner` = `Default`/runtime + the split guard.
 - **Analysis tooling is correct.** → `tests/Unit/ConflictMatrix.Tests.ps1`, `tests/Unit/ConflictMatrixDrift.Tests.ps1`.
 - **`tests/` and `tools/` stay analyzer-clean.** → `AnalyzeTests` / `AnalyzeTools` build tasks (throw on any finding; `tests/` excludes only `PSUseDeclaredVarsMoreThanAssignments`).
@@ -114,7 +116,7 @@ Every tracked assembly is classified into exactly one of:
 - **Runtime adjudication — non-auth tier (CI-capable):** strict per-module ALC snapshots (module/probe failures are fatal) + the four-module import/composition smoke.
 - **Runtime adjudication — auth tier (maintainer-run; future Stage 2b automatable via GitHub OIDC + Entra federated credential):** real `Connect-*` to a dev tenant. This is the sign-off for any change to the bundled set.
 - **Publish trigger:** `Release-and-Publish` publishes a merged PR only when it passes **both** the bundle-affecting **path gate** and the Conventional-Commit **version gate** — see §8.1 for the full contract (including how a Dependabot `deps:` commit maps to a **minor** release). CI-, policy-, docs-, test-, and tooling-only changes do **not** publish a new gallery version; `workflow_dispatch` is the deliberate-release escape hatch.
-- **Dependency PRs (Dependabot):** the bumped *bundle* is validated by **Build Module** (full build under `--locked-mode` + the #193/Azure.Core repro guards), bounded by the csproj floating-with-cap constraints. The Upstream-Compatibility `pr-smoke` adds an **upstream conflict-surface freshness check** — explicitly *not* a bundle validation, since a self-bump does not move the upstream fingerprint. See §8.2 for the full dependency lifecycle (the Dependabot `deps:` prefix now publishes a **minor** release). **Enforcement caveat:** these signals only block `gh pr merge --auto` if the build + Dependency Review checks are configured as **required status checks** (see §10).
+- **Dependency PRs (Dependabot):** the bumped *bundle* is validated by **Build Module** (full build under `--locked-mode` + the #193/Azure.Core repro guards), bounded by the csproj floating-with-cap constraints. The Upstream-Compatibility `pr-smoke` adds an upstream-latest freshness check for policy/tooling changes, and the scheduled candidate flow performs live inventory, drift detection, TFM alignment, and candidate PR generation.
 
 ## 8. Release & dependency-update contract
 
@@ -169,6 +171,7 @@ When changing the preload contract, follow this loop:
 5. **Realize** in `DLLPickle.csproj` (preload = bundled reference; block = excluded, incl. `ExcludeAssets` for blocked transitives), regenerate `packages.lock.json`.
 6. **Validate** (non-auth gates always; auth tier for any bundled-set change).
 7. **Update this blueprint** if the contract or invariants changed.
+8. **Update the gap register** if the work opens, advances, resolves, blocks, supersedes, or intentionally accepts a tracked gap.
 
 The baseline is a reproducible snapshot, not just a hash: `baseline.conflictSurface` stores every diverging assembly's `name`, sorted `versions`, and sorted `shippedBy` contributors alongside the module versions and fingerprint. Baseline refreshes must resolve all monitored versions before downloading any module, then prove that the stored rows recompute to the recorded fingerprint. Version-only moves are material drift and require adjudication; they do not pass silently.
 
@@ -180,16 +183,29 @@ Issue #239 was adjudicated on 2026-06-20 against Microsoft.Graph.Authentication 
 - Changes to the **bundled set** are behavior-changing and require the auth-tier real-environment sign-off before merge (the 2.0.1 precedent). They are **not** auto-merged.
 - Commit/push only when the maintainer asks.
 - Never hand-edit `module/` (generated). Never weaken analyzer settings to silence a finding — fix the code or scope a justified suppression.
+- Do not mark a `docs/gaps/GAP-*.md` item `resolved` unless the implementation, tests or explicit test rationale, and documentation updates are complete and linked.
 
 ## 10. Known gaps / follow-ups
 
-- **Required status checks.** The "Protect Main" ruleset enforces a PR (with review-thread resolution), Copilot review, code quality, and three required status checks: **`Build gate`**, **`Validate upstream compatibility tooling`**, and **`dependency-review`**. `Validate upstream compatibility tooling` is the always-reported aggregate over changed-file detection and the conditional Windows validation worker; policy, dependency, and fingerprint-generator changes also run a fresh live inventory. Keep the workflows triggered on every PR and condition jobs internally—workflow-level path filters can leave required checks pending. Dependabot auto-merge is restricted to the exact csproj/lock-file allow-list and waits on all three contexts.
+Detailed status for open and in-progress maintenance traps is tracked in the [gap register](gaps/README.md). Keep this section focused on architecture context; keep item state, checklists, and resolution links in the individual gap files.
+
+| Gap | Status | Architecture note |
+| --- | --- | --- |
+| [GAP-001](gaps/GAP-001-dependency-policy-realization-guard.md) | in-progress | Adds the executable realization guard for policy/csproj/built-output drift. |
+| [GAP-002](gaps/GAP-002-az-resources-monitoring.md) | open | `Az.Resources` is the observed #193 collision source but is not currently in `monitoredModules`. |
+| [GAP-003](gaps/GAP-003-exo-teams-probe-commands.md) | open | EXO/Teams ALC ownership is not yet captured because bare `Import-Module` does not eagerly load their identity assemblies. |
+| [GAP-004](gaps/GAP-004-vscode-powershelleditorservices-host.md) | open | VS Code / PowerShellEditorServices host behavior is not yet modeled for issue #169. |
+| [GAP-005](gaps/GAP-005-odata-conflict-expectation-management.md) | open | OData/#174 remains a known unsolved single-process incompatibility; guard expectations and user docs must stay current. |
+| [GAP-006](gaps/GAP-006-release-dispatch-process-trap.md) | open | Packaging/release-logic changes may require deliberate `workflow_dispatch` because non-bundle paths do not auto-publish. |
+| [GAP-007](gaps/GAP-007-required-status-check-ruleset-audit.md) | open | Required status-check ruleset configuration lives partly outside the repository and needs an auditable repo-local snapshot or procedure. |
+| [GAP-008](gaps/GAP-008-manifest-export-drift.md) | open | Manifest `FunctionsToExport` should be guarded against drift from intended public functions. |
+
+Historical/resolved notes remain below when they explain the current architecture or release contract.
+
 - **Dependency bumps publish on their own — `deps → minor` (decisions 3 & 4).** *Resolved.* `Get-VersionBump.ps1` now recognizes Dependabot's NuGet `deps:` commit prefix (`.github/dependabot.yml`) as a **minor** release prefix (§8.1), so an auto-approved, squash-merged minor/patch dependency bump satisfies both the path gate and the version gate and publishes a **minor** module release. (A maintainer-promoted major dependency PR still carries `breaking:`.) Covered by `tests/Unit/GetVersionBump.Tests.ps1`.
 - **Major-dependency draft-PR flow.** *Resolved.* `Dependabot-Auto-Approve.yml` converts a `version-update:semver-major` PR to a **draft** (`gh pr ready --undo`) and posts structured notes (version delta, NuGet package link, TFM-alignment references, Build gate / CI links, conflict-surface / `dependency-policy.json` impact, and a maintainer checklist) instead of the former generic comment. Majors remain excluded from `gh pr merge --auto`. Guarded by `tests/Unit/WorkflowGuardrails.Tests.ps1`.
 - **Explicit TFM-alignment inspection (Step 0b).** *Resolved.* `tools/Test-DLLPickleTfmAlignment.ps1` inspects each preload package's `lib/<tfm>/` assets (or a legacy flat `lib/`) and asserts a net8.0/netstandard2.0-compatible asset is present, complementing the `Build gate` (Step 0a). It runs fail-closed in the scheduled Upstream-Compatibility candidate flow and is referenced from the major-dependency draft-PR notes. (`Get-DLLPickleUpstreamInventory.ps1` still captures only assembly `Name`/`Version`/`FullName`; the TFM assertion lives in the dedicated tool, which inspects the restored NuGet package layout.) Covered by `tests/Unit/TfmAlignment.Tests.ps1`.
 - **Platform-support contract vs. manifest edition (decision 2).** The inspection/diagnostic tier is intended to be cross-edition (§1.2), but the manifest declares `CompatiblePSEditions = @('Core')`, so *importing* the module under Windows PowerShell 5.1 surfaces a compatibility warning. The supported manual-remediation path is therefore to run the inspection helpers **from a PowerShell 7.4+ session** while they scan the Windows PowerShell module roots — not to import DLLPickle under 5.1. Two code paths back this cross-edition intent on purpose: `Set-DPConfig` keeps a `$PSEdition`-aware encoding fallback, and `Find-DLLInPSModulePath` seeds the `WindowsPowerShell\Modules` roots (the all-users WinPS root only when actually running on 5.1). These are intentional, not residual dead code; recorded here so the contract is explicit.
-- **`Az.Resources` is not in `monitoredModules`.** It is the observed #193 collision source, but its copy and future drift are **not** inventoried. Among monitored modules the `Microsoft.Extensions.*` transitives are observed only in `MicrosoftTeams` (a single shipper → not in the conflict surface), recorded as `trackingScope` on the blocked entries. Note #193 was a *bundle-vs-consumer* collision (DLLPickle's preloaded copy vs Az.Resources'), which the cross-module drift gate does not model — the regression guard is the integration test that keeps these transitives out of `bin`, not the matrix. Re-adjudicate manually if an Az.Resources change is suspected, or add it to `monitoredModules` to track it directly.
-- **EXO/Teams ALC ownership** is not yet captured — a bare `Import-Module` doesn't eager-load their identity assemblies; the probe needs a representative `-ProbeCommand`.
 - **Multi-TFM (net9.0/net10.0):** deferred; the methodology is TFM-parameterizable. net9.0/net10.0 are ALC-capable, so the `block` verdicts in §3 carry over to them. The `net8.0` bundle is confirmed to load on **PS 7.6 / .NET 10 via roll-forward** (Az.Resources import verified, no #193 regression) — a positive signal that multi-TFM is mostly a packaging exercise, not a behavioral one, on ALC-capable runtimes. When it lands, `dependency-policy.json` preload entries (currently a single `targetFramework: net8.0` each) and the `Update-DLLPickleDependencyPins` tooling will need a per-TFM representation; the `RestoreDependencies` task already parses both `TargetFramework` and `TargetFrameworks` in anticipation.
 - **Re-introducing Windows PowerShell 5.1 / net48 (no ALC) — checklist if attempted:** because net48 has no `AssemblyLoadContext`, modules cannot self-isolate and the §3 `block` verdicts for the Azure SDK stack **invert**. Re-support would require: (1) multi-targeting the build to `net48` alongside `net8.0`; (2) **conditionally preloading the Azure SDK stack** (`Azure.Core` + `Azure.Identity`/`Broker` + `System.ClientModel`) for net48 only — pinned to the highest version the WinPS-supported module set agrees on, as #183 did; (3) restoring net48-specific dependency conditions in `DLLPickle.csproj` (e.g. `Condition="'$(TargetFramework)' == 'net48'"`); (4) restoring `CompatiblePSEditions = @('Core','Desktop')` and lowering the manifest `PowerShellVersion`, plus per-edition guards in `Import-DPLibrary`; (5) adding WinPS 5.1 to the CI test matrix and re-validating the #156/#165-class scenarios. The 2.0 refactor's mistake was applying the net48-era Azure.Core preload to net8 unconditionally — any re-introduction must keep it **strictly TFM-conditional**.
 - **Planned feature enhancements (backlog).** Forward-looking ideas consolidated from the former root `Roadmap.md`; not yet scheduled, order is not guaranteed, and large dependency/platform shifts may change priority. (Released and in-progress work lives in [CHANGELOG.md](../CHANGELOG.md) — for example the `Microsoft.PowerShell.PlatyPS` help-generation migration is already tracked there, and the broader PowerShell 7.4+ compatibility and supply-chain hardening work is the ongoing subject of §3, §8, and §9.)

--- a/docs/gaps/GAP-001-dependency-policy-realization-guard.md
+++ b/docs/gaps/GAP-001-dependency-policy-realization-guard.md
@@ -1,0 +1,70 @@
+---
+id: GAP-001
+title: Add dependency policy realization guard
+status: in-progress
+severity: high
+area: dependency-policy
+owner: maintainer
+created: 2026-06-23
+updated: 2026-06-23
+related_issues: []
+related_prs:
+  - https://github.com/SamErde/DLLPickle/pull/257
+related_docs:
+  - docs/Architecture.md
+  - build/dependency-policy.json
+  - src/DLLPickle.Build/DLLPickle.csproj
+related_tests:
+  - tests/Integration/DependencyPolicyRealization.Tests.ps1
+resolution_pr: https://github.com/SamErde/DLLPickle/pull/257
+resolved_on:
+---
+
+# GAP-001 — Add dependency policy realization guard
+
+## Status
+
+**Current status:** In progress.
+
+Implementation is in draft PR #257. Keep this gap in `in-progress` until the PR merges and the test is confirmed in CI.
+
+## Problem
+
+`build/dependency-policy.json` is the decision source of truth for preload and block classifications, while `src/DLLPickle.Build/DLLPickle.csproj` and the generated `module/DLLPickle/bin/net8.0` output realize the actual bundle. Without an executable realization guard, a future dependency or packaging change can drift away from the policy without failing CI.
+
+## Why this matters
+
+This is a high-risk maintenance trap because the policy can look correct during review while the shipped bundle contains missing preload assemblies, blocked assemblies, or unclassified transitive assemblies.
+
+## Current evidence
+
+- `docs/Architecture.md` identifies `build/dependency-policy.json` as the classification source of truth.
+- `docs/Architecture.md` identifies `DLLPickle.csproj` and `packages.lock.json` as the source of what is actually bundled.
+- Draft PR #257 adds an integration guard for this gap.
+
+## Desired end state
+
+The repository has an automated integration test that compares the policy, project references, and built output, and fails closed on preload/block/bundle drift.
+
+## Acceptance criteria
+
+- [x] A test exists that asserts every `preload` package is represented in `DLLPickle.csproj`.
+- [x] A test exists that asserts preload package references do not exclude runtime assets.
+- [x] A test exists that asserts blocked package references exclude runtime assets when they are present in `DLLPickle.csproj`.
+- [x] A test exists that asserts every preload assembly appears in the built `bin/net8.0` output.
+- [x] A test exists that asserts blocked assemblies do not appear in the built `bin/net8.0` output.
+- [x] A test exists that asserts the built `bin/net8.0` output does not contain unclassified managed assemblies.
+- [ ] PR #257 has merged.
+- [ ] The gap frontmatter is updated to `status: resolved` after merge.
+- [ ] `docs/gaps/README.md` is updated after merge.
+
+## Implementation notes for Codex
+
+1. Inspect PR #257 before changing this gap.
+2. Do not duplicate the test unless PR #257 is closed without merge.
+3. After PR #257 merges, update this file and `docs/gaps/README.md` in the merge-follow-up PR, or in the same PR if the branch is rebased before merge.
+4. Do not mark this gap `resolved` until the resolving PR is merged.
+
+## Resolution notes
+
+Pending merge of PR #257.

--- a/docs/gaps/GAP-002-az-resources-monitoring.md
+++ b/docs/gaps/GAP-002-az-resources-monitoring.md
@@ -1,0 +1,66 @@
+---
+id: GAP-002
+title: Track Az.Resources as a monitored collision source
+status: open
+severity: high
+area: dependency-policy
+owner: maintainer
+created: 2026-06-23
+updated: 2026-06-23
+related_issues:
+  - "193"
+related_prs: []
+related_docs:
+  - docs/Architecture.md
+  - build/dependency-policy.json
+  - docs/DEPENDENCIES.md
+related_tests:
+  - tests/Integration/DLLPickle.IntegrationTest.Tests.ps1
+resolution_pr:
+resolved_on:
+---
+
+# GAP-002 — Track Az.Resources as a monitored collision source
+
+## Status
+
+**Current status:** Open.
+
+## Problem
+
+`Az.Resources` is the observed source of the #193 `Microsoft.Extensions.*` collision, but it is not currently included in the monitored module set used by the upstream inventory and conflict-surface drift process.
+
+## Why this matters
+
+The existing regression guard keeps the blocked `Microsoft.Extensions.*` transitives out of the DLLPickle bundle, but the upstream drift model does not directly observe future `Az.Resources` changes. A future `Az.Resources` dependency shift could matter without appearing in the current monitored-module inventory.
+
+## Current evidence
+
+- `docs/Architecture.md` records `Az.Resources` as the #193 collision source.
+- `docs/Architecture.md` also records that `Az.Resources` is not in `monitoredModules`.
+- `dependency-policy.json` currently tracks the blocked transitives with `trackingScope` evidence, but does not inventory `Az.Resources` directly.
+
+## Desired end state
+
+The repository either monitors `Az.Resources` directly or documents a deliberate decision not to do so with a compensating guard.
+
+## Acceptance criteria
+
+- [ ] Decide whether `Az.Resources` should be added to `monitoredModules`.
+- [ ] If added, update `build/dependency-policy.json` and refresh the baseline/fingerprint using the established upstream inventory process.
+- [ ] If not added, document the rationale and compensating guard in this gap and `docs/Architecture.md`.
+- [ ] Update or add tests so future workflow/policy changes preserve the decision.
+- [ ] Update `docs/DEPENDENCIES.md` if the monitored-module lifecycle changes.
+- [ ] Update `docs/gaps/README.md` and this file when resolved or superseded.
+
+## Implementation notes for Codex
+
+1. Read `docs/Architecture.md` §3, §5, §8, §9, and §10 before changing policy.
+2. Read `build/dependency-policy.json` and identify the current `monitoredModules`, blocked entries, and `baseline.conflictSurface` fields.
+3. Treat changes to monitoring scope as policy changes that require review.
+4. Prefer an automated guard in `tests/Unit/WorkflowGuardrails.Tests.ps1` or an equivalent policy test if the decision can be expressed structurally.
+5. Do not mark this gap `resolved` unless the monitoring decision and related documentation are updated.
+
+## Resolution notes
+
+Pending.

--- a/docs/gaps/GAP-003-exo-teams-probe-commands.md
+++ b/docs/gaps/GAP-003-exo-teams-probe-commands.md
@@ -1,0 +1,64 @@
+---
+id: GAP-003
+title: Add representative EXO and Teams probe commands
+status: open
+severity: high
+area: runtime-probes
+owner: maintainer
+created: 2026-06-23
+updated: 2026-06-23
+related_issues: []
+related_prs: []
+related_docs:
+  - docs/Architecture.md
+  - build/dependency-policy.json
+  - docs/DEPENDENCIES.md
+related_tests: []
+resolution_pr:
+resolved_on:
+---
+
+# GAP-003 — Add representative EXO and Teams probe commands
+
+## Status
+
+**Current status:** Open.
+
+## Problem
+
+The runtime ALC ownership probe can capture module behavior after bare `Import-Module`, but ExchangeOnlineManagement and MicrosoftTeams may not eagerly load the identity assemblies that matter until representative commands run.
+
+## Why this matters
+
+DLLPickle's preload/block classification depends on observed runtime ownership, not static package inventory alone. If EXO or Teams loads identity assemblies only after command execution, bare import probes can under-model default-ALC consumers and create false confidence.
+
+## Current evidence
+
+- `docs/Architecture.md` says static narrows but runtime decides.
+- `docs/Architecture.md` records that EXO/Teams ALC ownership is not yet captured because bare `Import-Module` does not eagerly load their identity assemblies.
+
+## Desired end state
+
+The runtime probe system supports representative `-ProbeCommand` execution for EXO and Teams, and the policy or tooling documents which probe commands establish ALC ownership for those modules.
+
+## Acceptance criteria
+
+- [ ] Define safe, representative probe commands for ExchangeOnlineManagement and MicrosoftTeams.
+- [ ] Update the relevant runtime probe tooling to support module-specific probe commands if it does not already.
+- [ ] Record the selected probe commands in `build/dependency-policy.json` or another authoritative policy/configuration file.
+- [ ] Add tests for probe-command configuration parsing and invocation behavior without requiring live authentication.
+- [ ] Document which probes are CI-capable and which require maintainer-run/auth-tier validation.
+- [ ] Update `docs/Architecture.md` §7, §9, or §10 as needed.
+- [ ] Update `docs/gaps/README.md` and this file when resolved or superseded.
+
+## Implementation notes for Codex
+
+1. Do not invent authenticated commands that require production tenant access.
+2. Prefer no-op or discovery commands that are safe, read-only, and can be skipped or documented when authentication is unavailable.
+3. Keep CI-capable probes separate from maintainer-run auth-tier probes.
+4. Add structural tests for the tooling even if live EXO/Teams execution remains maintainer-run only.
+5. Do not mark this gap `resolved` unless the probe-command contract is documented and tested.
+
+## Resolution notes
+
+Pending.

--- a/docs/gaps/GAP-004-vscode-powershelleditorservices-host.md
+++ b/docs/gaps/GAP-004-vscode-powershelleditorservices-host.md
@@ -1,0 +1,64 @@
+---
+id: GAP-004
+title: Model VS Code and PowerShellEditorServices host behavior
+status: open
+severity: medium
+area: host-context
+owner: maintainer
+created: 2026-06-23
+updated: 2026-06-23
+related_issues:
+  - "169"
+related_prs: []
+related_docs:
+  - docs/Architecture.md
+  - docs/Deep-Dive.md
+related_tests: []
+resolution_pr:
+resolved_on:
+---
+
+# GAP-004 — Model VS Code and PowerShellEditorServices host behavior
+
+## Status
+
+**Current status:** Open.
+
+## Problem
+
+Issue #169 reports different behavior between Windows Terminal and the VS Code integrated terminal / PowerShellEditorServices host context. DLLPickle's current validation model is mostly normal `pwsh` process behavior and may not model assemblies preloaded by the editor host.
+
+## Why this matters
+
+Many users run Microsoft Graph, Azure, and Exchange commands inside VS Code. If PowerShellEditorServices or the integrated terminal preloads conflicting assemblies before DLLPickle can act, DLLPickle may appear unreliable in one of the most common development hosts.
+
+## Current evidence
+
+- Issue #169 reports Graph authentication behavior that differs between Windows Terminal and VS Code.
+- Existing runtime validation focuses on normal PowerShell sessions, not editor-host bootstrap behavior.
+
+## Desired end state
+
+The repository documents the VS Code / PowerShellEditorServices host scenario and either adds a reproducible validation path or records a clear limitation with user guidance.
+
+## Acceptance criteria
+
+- [ ] Reproduce or characterize the VS Code / PowerShellEditorServices host behavior in issue #169.
+- [ ] Identify whether the issue is caused by the integrated terminal, PowerShell extension host, PowerShellEditorServices, profile scripts, or another preload source.
+- [ ] Add a maintainer-run repro script or documented diagnostic procedure.
+- [ ] Add an automated structural test when practical, or document why a live/editor-host test is not CI-suitable.
+- [ ] Update `docs/Deep-Dive.md` with user-facing guidance if the limitation remains.
+- [ ] Update `docs/Architecture.md` if host-context assumptions affect the preload model.
+- [ ] Update `docs/gaps/README.md` and this file when resolved, blocked, or superseded.
+
+## Implementation notes for Codex
+
+1. Search for issue #169 references before editing.
+2. Do not assume VS Code integrated terminal and PowerShellEditorServices are the same host path.
+3. Preserve the distinction between normal `pwsh` sessions and editor-integrated host behavior.
+4. Prefer user-safe diagnostics over hidden environment assumptions.
+5. Do not mark this gap `resolved` unless the repo contains either a validation path or explicit documented limitation.
+
+## Resolution notes
+
+Pending.

--- a/docs/gaps/GAP-005-odata-conflict-expectation-management.md
+++ b/docs/gaps/GAP-005-odata-conflict-expectation-management.md
@@ -1,0 +1,68 @@
+---
+id: GAP-005
+title: Strengthen OData conflict expectation management
+status: open
+severity: medium
+area: known-conflicts
+owner: maintainer
+created: 2026-06-23
+updated: 2026-06-23
+related_issues:
+  - "174"
+related_prs: []
+related_docs:
+  - docs/Architecture.md
+  - docs/Deep-Dive.md
+  - src/DLLPickle/KnownConflicts.json
+  - docs/superpowers/specs/2026-06-01-issue174-conflict-warning-design.md
+  - docs/superpowers/plans/2026-06-01-issue174-conflict-warning.md
+related_tests:
+  - tests/Integration/DLLPickle.Issue174.OData.Tests.ps1
+resolution_pr:
+resolved_on:
+---
+
+# GAP-005 — Strengthen OData conflict expectation management
+
+## Status
+
+**Current status:** Open.
+
+## Problem
+
+The Az.Storage and ExchangeOnlineManagement OData conflict is documented and warning-backed, but it remains intentionally unsolved in a single process. That limitation can be mistaken for a fixable preload gap unless the expectation is explicit in user docs, known-conflict data, tests, and architecture notes.
+
+## Why this matters
+
+Trying to make DLLPickle solve #174 by preloading OData can break Az.Storage or ExchangeOnlineManagement depending on import order. The safe workaround is separate PowerShell processes or sessions. Codex and maintainers need to preserve that expectation unless upstream module behavior changes.
+
+## Current evidence
+
+- Issue #174 is represented as a known conflict.
+- The architecture records OData assemblies as `block` / report-only.
+- The existing plan and design docs describe warning behavior rather than an automatic preload fix.
+
+## Desired end state
+
+The repository makes it unambiguous that #174 is a known unsolved cross-module incompatibility, not a missing preload target, and tests guard against accidentally treating OData as preloadable.
+
+## Acceptance criteria
+
+- [ ] Confirm `src/DLLPickle/KnownConflicts.json` clearly describes the #174 behavior and workaround.
+- [ ] Confirm user-facing docs explain that the workaround is separate PowerShell processes/sessions, not a single-process preload fix.
+- [ ] Confirm tests fail if OData assemblies are added back to the preload bundle without a deliberate re-adjudication.
+- [ ] Update the issue #174 plan/spec notes if they are stale after the committed-source relocation.
+- [ ] Add or update an architecture note that future OData changes require runtime re-adjudication, not static dependency updates alone.
+- [ ] Update `docs/gaps/README.md` and this file when resolved or superseded.
+
+## Implementation notes for Codex
+
+1. Treat OData as `block` unless runtime evidence proves both import orders work in one process.
+2. Do not remove the separate-session workaround unless tests and runtime evidence prove it is obsolete.
+3. Keep known-conflict data, tests, and user docs synchronized.
+4. Prefer updating stale plan/spec supersession notes rather than rewriting historical design rationale.
+5. Do not mark this gap `resolved` unless user-facing expectation management and regression guards are both current.
+
+## Resolution notes
+
+Pending.

--- a/docs/gaps/GAP-006-release-dispatch-process-trap.md
+++ b/docs/gaps/GAP-006-release-dispatch-process-trap.md
@@ -1,0 +1,65 @@
+---
+id: GAP-006
+title: Document manual release dispatch process trap
+status: open
+severity: medium
+area: release-process
+owner: maintainer
+created: 2026-06-23
+updated: 2026-06-23
+related_issues: []
+related_prs: []
+related_docs:
+  - docs/Architecture.md
+  - CHANGELOG.md
+  - .github/workflows/Release-and-Publish.yml
+related_tests:
+  - tests/Unit/WorkflowGuardrails.Tests.ps1
+resolution_pr:
+resolved_on:
+---
+
+# GAP-006 — Document manual release dispatch process trap
+
+## Status
+
+**Current status:** Open.
+
+## Problem
+
+The release workflow is intentionally path-gated so docs, policy, test, tooling, and release-logic-only changes do not publish automatically. That protects the gallery, but it creates a process trap: packaging or release-logic changes may require deliberate `workflow_dispatch` to publish even when the code path is correct.
+
+## Why this matters
+
+A maintainer or agent can merge a packaging/release-logic change and assume it has shipped. If the change does not touch bundle-affecting paths and does not pass the publish gates, no PowerShell Gallery release occurs unless the manual release path is used deliberately.
+
+## Current evidence
+
+- `docs/Architecture.md` documents the path gate and version gate.
+- `docs/Architecture.md` identifies `workflow_dispatch` as the deliberate-release escape hatch.
+- The release workflow is designed to avoid publishing docs/test/tooling-only changes.
+
+## Desired end state
+
+The repository contains clear maintainer-facing instructions for when and how to use manual release dispatch, and tests preserve the intended release-gating behavior.
+
+## Acceptance criteria
+
+- [ ] Add a maintainer-facing release dispatch note to `docs/Architecture.md`, `CHANGELOG.md`, or a dedicated release document.
+- [ ] Document examples of changes that do and do not publish automatically.
+- [ ] Document when `workflow_dispatch` is appropriate.
+- [ ] Confirm workflow guardrail tests cover the path gate and manual-dispatch expectations where practical.
+- [ ] Update PR/release guidance so Codex does not claim that non-bundle changes are shipped automatically.
+- [ ] Update `docs/gaps/README.md` and this file when resolved or superseded.
+
+## Implementation notes for Codex
+
+1. Preserve the distinction between publishing a module version and merging repository-only changes.
+2. Do not weaken the release path gate to close this gap unless the architecture decision changes.
+3. Prefer documentation and guardrail tests over broadening release triggers.
+4. Update all references that mention the escape hatch if wording changes.
+5. Do not mark this gap `resolved` unless the manual release path is documented for maintainers and agents.
+
+## Resolution notes
+
+Pending.

--- a/docs/gaps/GAP-007-required-status-check-ruleset-audit.md
+++ b/docs/gaps/GAP-007-required-status-check-ruleset-audit.md
@@ -1,0 +1,65 @@
+---
+id: GAP-007
+title: Audit required status-check ruleset configuration
+status: open
+severity: medium
+area: branch-protection
+owner: maintainer
+created: 2026-06-23
+updated: 2026-06-23
+related_issues: []
+related_prs: []
+related_docs:
+  - docs/Architecture.md
+  - .github/workflows/Build-Module.yml
+  - .github/workflows/Upstream-Compatibility.yml
+  - .github/workflows/Dependabot-Auto-Approve.yml
+related_tests:
+  - tests/Unit/WorkflowGuardrails.Tests.ps1
+resolution_pr:
+resolved_on:
+---
+
+# GAP-007 — Audit required status-check ruleset configuration
+
+## Status
+
+**Current status:** Open.
+
+## Problem
+
+The required status checks and ruleset configuration live partly outside the repository. The workflows and guardrail tests can ensure that expected check names exist, but they cannot prove the GitHub repository ruleset is configured correctly unless the ruleset is exported, documented, or otherwise audited.
+
+## Why this matters
+
+A required-check mismatch can leave PRs blocked forever, or worse, leave intended protection unenforced. Workflow-level path filters can also make required checks stay pending if the repository ruleset requires a check that does not run for a PR.
+
+## Current evidence
+
+- `docs/Architecture.md` documents required checks and warns that workflows should be triggered on every PR while condition jobs internally.
+- `WorkflowGuardrails.Tests.ps1` contains structural checks for workflow behavior, but the GitHub-hosted ruleset itself remains an external configuration dependency.
+
+## Desired end state
+
+The repository has a documented, auditable snapshot or procedure for verifying required checks and branch/ruleset settings against workflow behavior.
+
+## Acceptance criteria
+
+- [ ] Export or document the current main-protection ruleset configuration.
+- [ ] Record the expected required status-check contexts in a repo-local document or test fixture.
+- [ ] Add or update a guardrail test that compares expected check names to workflow aggregate job names when practical.
+- [ ] Document a maintainer procedure for auditing the external ruleset after workflow renames.
+- [ ] Update `docs/Architecture.md` if required-check names, behavior, or ruleset assumptions change.
+- [ ] Update `docs/gaps/README.md` and this file when resolved or superseded.
+
+## Implementation notes for Codex
+
+1. Do not assume repository ruleset state from workflow files alone.
+2. If GitHub API access is available, prefer an export or generated snapshot that can be reviewed.
+3. If API access is not available, add a manual audit procedure and clearly mark the external dependency.
+4. Do not rename aggregate required-check jobs without updating the ruleset documentation and tests.
+5. Do not mark this gap `resolved` unless external ruleset verification is documented or captured.
+
+## Resolution notes
+
+Pending.

--- a/docs/gaps/GAP-008-manifest-export-drift.md
+++ b/docs/gaps/GAP-008-manifest-export-drift.md
@@ -1,0 +1,62 @@
+---
+id: GAP-008
+title: Guard manifest export drift
+status: open
+severity: low
+area: module-manifest
+owner: maintainer
+created: 2026-06-23
+updated: 2026-06-23
+related_issues: []
+related_prs: []
+related_docs:
+  - docs/Architecture.md
+  - src/DLLPickle/DLLPickle.psd1
+  - src/DLLPickle/Public
+related_tests: []
+resolution_pr:
+resolved_on:
+---
+
+# GAP-008 — Guard manifest export drift
+
+## Status
+
+**Current status:** Open.
+
+## Problem
+
+The source manifest has an explicit `FunctionsToExport` list, while development/build behavior can also rely on public function discovery and merged module output. Without a guard, the manifest export list can drift from the public functions that should be exported.
+
+## Why this matters
+
+A public function can be added but not exported, or a removed/renamed function can remain in the manifest. Either case causes user-visible behavior to diverge from source layout and documentation.
+
+## Current evidence
+
+- `docs/Architecture.md` identifies `src/DLLPickle/` as the module source and `src/DLLPickle/DLLPickle.psd1` as part of the platform-support contract.
+- The source tree uses a `Public` folder convention, while the manifest export list remains an explicit contract.
+
+## Desired end state
+
+The repository has a test that keeps `FunctionsToExport` aligned with the intended public function set, or it documents an intentional exception model.
+
+## Acceptance criteria
+
+- [ ] Decide whether `FunctionsToExport` should exactly match `src/DLLPickle/Public/*.ps1` function names.
+- [ ] Add a Pester test that compares the manifest export list to the intended public function list, or document any explicit exceptions.
+- [ ] Update docs if public export behavior is part of the supported contract.
+- [ ] Ensure the test runs in the regular unit/analyzer path.
+- [ ] Update `docs/gaps/README.md` and this file when resolved or superseded.
+
+## Implementation notes for Codex
+
+1. Read the source manifest and public function folder before editing.
+2. Preserve intentional export decisions if any function is deliberately private despite location.
+3. Prefer a deterministic Pester test over generated manifest mutation.
+4. Keep the test compatible with PowerShell 7.4+ repository tooling.
+5. Do not mark this gap `resolved` unless export drift is guarded or intentionally documented.
+
+## Resolution notes
+
+Pending.

--- a/docs/gaps/GAP-009-merged-root-module-order.md
+++ b/docs/gaps/GAP-009-merged-root-module-order.md
@@ -1,0 +1,60 @@
+---
+id: GAP-009
+title: Make merged root-module script order deterministic
+status: open
+severity: low
+area: build-output
+owner: maintainer
+created: 2026-06-23
+updated: 2026-06-23
+related_issues: []
+related_prs: []
+related_docs:
+  - docs/Architecture.md
+  - build/DLLPickle.Build.ps1
+related_tests: []
+resolution_pr:
+resolved_on:
+---
+
+# GAP-009 — Make merged root-module script order deterministic
+
+## Status
+
+**Current status:** Open.
+
+## Problem
+
+The merged root module output depends on recursive source-file discovery. If discovery order is not explicitly sorted and tested, the generated module can change across filesystems, platforms, or future refactors.
+
+## Why this matters
+
+A nondeterministic merge order can create hard-to-debug import behavior when private/public function files gain ordering assumptions, and it can add noise to generated output or release artifacts.
+
+## Current evidence
+
+- The architecture identifies `module/DLLPickle/` as generated output rebuilt by `PrepareModuleOutput`.
+- The build process merges source files into the module output.
+
+## Desired end state
+
+The build has an explicit deterministic ordering rule for merged source files, and a test or documented guard preserves it.
+
+## Acceptance criteria
+
+- [ ] Inspect the build merge logic and identify the current ordering rule.
+- [ ] If ordering is implicit, make it explicit with a stable sort.
+- [ ] Add or update a test that detects nondeterministic merge ordering when practical.
+- [ ] Document any required ordering convention for public/private scripts.
+- [ ] Update `docs/gaps/README.md` and this file when resolved or superseded.
+
+## Implementation notes for Codex
+
+1. Do not hand-edit generated `module/` output.
+2. Prefer a build-script fix plus a structural test over relying on platform-specific `Get-ChildItem` behavior.
+3. Avoid introducing source-file ordering dependencies unless they are documented and tested.
+4. Do not mark this gap `resolved` unless deterministic ordering is verified or intentionally accepted.
+
+## Resolution notes
+
+Pending.

--- a/docs/gaps/GAP-010-unresolved-review-thread-maintenance.md
+++ b/docs/gaps/GAP-010-unresolved-review-thread-maintenance.md
@@ -1,0 +1,60 @@
+---
+id: GAP-010
+title: Define unresolved review-thread maintenance workflow
+status: open
+severity: low
+area: review-process
+owner: maintainer
+created: 2026-06-23
+updated: 2026-06-23
+related_issues: []
+related_prs: []
+related_docs:
+  - docs/Architecture.md
+  - .github/workflows/Build-Module.yml
+related_tests: []
+resolution_pr:
+resolved_on:
+---
+
+# GAP-010 — Define unresolved review-thread maintenance workflow
+
+## Status
+
+**Current status:** Open.
+
+## Problem
+
+The repository ruleset expects review-thread resolution, but the repo-local process for maintaining, auditing, and resolving stale review threads is not documented in the gap/architecture workflow.
+
+## Why this matters
+
+Unresolved review threads can block merges even after code changes address the underlying concern. Conversely, resolving threads without updating tests or docs can hide incomplete work.
+
+## Current evidence
+
+- The architecture records review-thread resolution as part of the main-protection expectation.
+- The external ruleset itself is not fully repo-local, which overlaps with GAP-007.
+
+## Desired end state
+
+The repository documents how maintainers and agents should handle unresolved review threads, including when to update a gap file, when to request maintainer review, and when not to resolve a thread.
+
+## Acceptance criteria
+
+- [ ] Decide whether this gap should be folded into GAP-007 or kept separate.
+- [ ] Document the review-thread maintenance workflow if kept separate.
+- [ ] Update the relevant PR guidance or architecture note.
+- [ ] Ensure the workflow does not encourage agents to resolve review threads without addressing the underlying issue.
+- [ ] Update `docs/gaps/README.md` and this file when resolved, superseded, or folded into GAP-007.
+
+## Implementation notes for Codex
+
+1. Prefer folding this into GAP-007 if the work is only ruleset/process documentation.
+2. Do not resolve review threads as a substitute for code, test, or documentation changes.
+3. If a review thread corresponds to a gap, link the gap file from the PR discussion or commit message.
+4. Do not mark this gap `resolved` unless the review-thread workflow is explicit or intentionally superseded.
+
+## Resolution notes
+
+Pending.

--- a/docs/gaps/GAP-011-docs-implementation-drift.md
+++ b/docs/gaps/GAP-011-docs-implementation-drift.md
@@ -1,0 +1,63 @@
+---
+id: GAP-011
+title: Guard docs and implementation drift for gap closures
+status: open
+severity: medium
+area: documentation
+owner: maintainer
+created: 2026-06-23
+updated: 2026-06-23
+related_issues: []
+related_prs: []
+related_docs:
+  - docs/Architecture.md
+  - docs/gaps/README.md
+  - docs/superpowers/plans
+  - docs/superpowers/specs
+related_tests: []
+resolution_pr:
+resolved_on:
+---
+
+# GAP-011 — Guard docs and implementation drift for gap closures
+
+## Status
+
+**Current status:** Open.
+
+## Problem
+
+Gap closure depends on agents updating implementation, tests, and related documentation together. The gap register and prompt define the convention, but there is not yet an automated guard that detects when a PR resolves a gap without updating the required related docs or index.
+
+## Why this matters
+
+Without a guard, Codex or a maintainer can fix code and mark a gap resolved while leaving `docs/Architecture.md`, `docs/gaps/README.md`, or older `docs/superpowers` plans/specs stale.
+
+## Current evidence
+
+- The gap register is a documentation/process system in this PR.
+- The repository already relies on architecture and superpowers docs as durable agent context.
+
+## Desired end state
+
+The repository has either a lightweight automated consistency check for gap files and the index, or a documented review checklist that is enforced by maintainers.
+
+## Acceptance criteria
+
+- [ ] Add a structural test or script that validates gap frontmatter status values.
+- [ ] Add a structural test or script that checks every `docs/gaps/GAP-*.md` file appears in `docs/gaps/README.md`.
+- [ ] Add a structural test or script that checks resolved gaps include `resolution_pr` and `resolved_on`.
+- [ ] Decide whether related docs updates can be tested structurally or must remain review-only.
+- [ ] Update `.github/prompts/maintain-gap.prompt.md` if the workflow changes.
+- [ ] Update `docs/gaps/README.md` and this file when resolved or superseded.
+
+## Implementation notes for Codex
+
+1. Prefer a small Pester test under `tests/Unit/` if the repository wants automated enforcement.
+2. Keep validation structural and deterministic; do not require GitHub API access for unit tests.
+3. Do not block normal documentation edits on overly complex parsing.
+4. Do not mark this gap `resolved` unless the register/index consistency rule is automated or explicitly accepted as review-only.
+
+## Resolution notes
+
+Pending.

--- a/docs/gaps/README.md
+++ b/docs/gaps/README.md
@@ -1,0 +1,54 @@
+# DLLPickle Gap Register
+
+This directory tracks open maintenance traps, automation gaps, and unresolved architecture follow-ups that should remain visible to maintainers and agentic workstreams.
+
+Use this register for durable repo-local gap state. Use `docs/superpowers/specs/` and `docs/superpowers/plans/` for larger point-in-time designs and task-by-task implementation plans.
+
+## Rules for maintainers and agents
+
+1. Treat each `GAP-*.md` file as the source of truth for that gap's current status.
+2. Do not mark a gap `resolved` unless all acceptance criteria in the gap file are checked or explicitly superseded.
+3. When resolving a gap, update:
+   - the gap file,
+   - this index,
+   - related tests,
+   - related source, policy, or workflow files,
+   - related documentation,
+   - `docs/Architecture.md` when architecture, invariants, validation gates, source-of-truth mappings, or known gaps changed.
+4. If a gap becomes obsolete because of a different design, mark it `superseded`, explain why, and link the superseding PR, issue, or document.
+5. If a gap cannot be completed safely, mark it `blocked`, explain the blocker, and leave the remaining acceptance criteria unchecked.
+6. Keep this index synchronized with each gap file's frontmatter.
+
+## Status values
+
+| Status | Meaning |
+| --- | --- |
+| `open` | Known gap with no active implementation PR. |
+| `in-progress` | Implementation is underway in a linked PR or branch. |
+| `blocked` | Work cannot proceed without an external decision, credential, environment, or dependency. |
+| `resolved` | Acceptance criteria are complete and the resolving PR is linked. |
+| `superseded` | A later design or decision made the gap obsolete. |
+| `wont-fix` | The gap is accepted intentionally, with rationale documented. |
+
+## Gap index
+
+| ID | Status | Area | Title | File |
+| --- | --- | --- | --- | --- |
+| GAP-001 | in-progress | dependency-policy | Add dependency policy realization guard | [GAP-001](GAP-001-dependency-policy-realization-guard.md) |
+| GAP-002 | open | dependency-policy | Track Az.Resources as a monitored collision source | [GAP-002](GAP-002-az-resources-monitoring.md) |
+| GAP-003 | open | runtime-probes | Add representative EXO and Teams probe commands | [GAP-003](GAP-003-exo-teams-probe-commands.md) |
+| GAP-004 | open | host-context | Model VS Code and PowerShellEditorServices host behavior | [GAP-004](GAP-004-vscode-powershelleditorservices-host.md) |
+| GAP-005 | open | known-conflicts | Strengthen OData conflict expectation management | [GAP-005](GAP-005-odata-conflict-expectation-management.md) |
+| GAP-006 | open | release-process | Document manual release dispatch process trap | [GAP-006](GAP-006-release-dispatch-process-trap.md) |
+| GAP-007 | open | branch-protection | Audit required status-check ruleset configuration | [GAP-007](GAP-007-required-status-check-ruleset-audit.md) |
+| GAP-008 | open | module-manifest | Guard manifest export drift | [GAP-008](GAP-008-manifest-export-drift.md) |
+
+## Agent workflow
+
+1. Start with the requested `GAP-*.md` file.
+2. Read every file listed in `related_docs`.
+3. Search the repository for the gap ID before editing.
+4. Make the smallest safe implementation that satisfies the acceptance criteria.
+5. Add or update tests before marking a gap resolved when an automated guard is practical.
+6. Update related documentation before finalizing the PR.
+7. Update this index and the gap file frontmatter in the same PR that resolves, blocks, supersedes, or intentionally accepts the gap.

--- a/docs/gaps/README.md
+++ b/docs/gaps/README.md
@@ -42,6 +42,9 @@ Use this register for durable repo-local gap state. Use `docs/superpowers/specs/
 | GAP-006 | open | release-process | Document manual release dispatch process trap | [GAP-006](GAP-006-release-dispatch-process-trap.md) |
 | GAP-007 | open | branch-protection | Audit required status-check ruleset configuration | [GAP-007](GAP-007-required-status-check-ruleset-audit.md) |
 | GAP-008 | open | module-manifest | Guard manifest export drift | [GAP-008](GAP-008-manifest-export-drift.md) |
+| GAP-009 | open | build-output | Make merged root-module script order deterministic | [GAP-009](GAP-009-merged-root-module-order.md) |
+| GAP-010 | open | review-process | Define unresolved review-thread maintenance workflow | [GAP-010](GAP-010-unresolved-review-thread-maintenance.md) |
+| GAP-011 | open | documentation | Guard docs and implementation drift for gap closures | [GAP-011](GAP-011-docs-implementation-drift.md) |
 
 ## Agent workflow
 


### PR DESCRIPTION
## Summary

- Adds `docs/gaps/` as a repo-local gap register for maintenance traps, automation gaps, and unresolved follow-ups.
- Adds structured `GAP-*.md` files with frontmatter, acceptance criteria, implementation notes for Codex, and resolution rules.
- Adds `.github/prompts/maintain-gap.prompt.md` so Codex in VS Code has a repeatable workflow for updating gap status, related docs, tests, and resolution metadata.
- Updates `docs/Architecture.md` to treat the gap register as the source of truth for open/in-progress gap status and to link the primary identified gaps from §10.

## Gaps included

- GAP-001: dependency policy realization guard, linked to draft PR #257.
- GAP-002: Az.Resources monitoring.
- GAP-003: EXO/Teams representative probe commands.
- GAP-004: VS Code / PowerShellEditorServices host behavior.
- GAP-005: OData conflict expectation management.
- GAP-006: manual release dispatch process trap.
- GAP-007: required status-check ruleset audit.
- GAP-008: manifest export drift.
- GAP-009: deterministic merged root-module ordering.
- GAP-010: unresolved review-thread maintenance workflow.
- GAP-011: docs/implementation drift for gap closures.

## Validation

- Not run locally in this environment: this branch was created through the GitHub connector rather than a local checkout.
- This is documentation and prompt metadata only; no source, workflow, or test behavior is changed.
- The gap index was synchronized with all `GAP-*.md` files included in this PR.
