### PR TITLE
feat(policy): resolve GAP-002 by monitoring Az.Resources drift source

### DIFF
--- a/build/dependency-policy.json
+++ b/build/dependency-policy.json
@@ -308,13 +308,13 @@
       }
     ],
     "validation": {
-      "pullRequest": 257,
+      "pullRequest": 264,
       "result": "tracked-conflict-classified-and-excluded",
-      "validatedOn": "2026-06-23",
+      "validatedOn": "2026-06-25",
       "evidence": [
-        "Tracking System.Security.Cryptography.ProtectedData exposed a 17th conflict row across Az.Accounts, ExchangeOnlineManagement, Microsoft.Graph.Authentication, and MicrosoftTeams at assembly versions 4.0.3.0, 7.0.0.0, and 9.0.0.0; the other 16 conflict rows and monitored module versions were unchanged.",
-        "The assembly is classified block because PowerShell supplies the runtime assembly and DLLPickle's Windows build had bundled the older 4.0.3.0 NuGet assembly transitively through Microsoft.Identity.Client.Extensions.Msal.",
-        "A direct ExcludeAssets=runtime reference removed the bundled copy, and the full Windows build passed the policy-realization guard plus 193 unit and 18 non-live integration tests."
+        "Adding Az.Resources to the monitored module set for issue #193 / GAP-002 refreshed the baseline capture on 2026-06-25, adding Az.Resources 10.0.0 to the monitored module versions and exposing Microsoft.Extensions.DependencyInjection.Abstractions as an 18th conflict row across Az.Resources and MicrosoftTeams at assembly versions 2.2.0.0 and 8.0.0.0; the prior 17 conflict rows were unchanged and Az.Resources is the only module that contributes the new row.",
+        "The assembly is classified block because the contributing modules already diverge on Microsoft.Extensions.DependencyInjection.Abstractions and DLLPickle must not re-bundle it; its paired Microsoft.Extensions.Logging.Abstractions is excluded alongside it but is shipped only by MicrosoftTeams, so it does not appear in the cross-module conflict surface.",
+        "The conflict-surface fingerprint was recomputed to 03b94d1603f2d7af09021a738fe9b7ed028dd18bba361e55bbe866bb1febaae0, and the refreshed baseline is exercised by the policy-realization guard and the dependency-policy unit and non-live integration suites."
       ]
     }
   },

--- a/build/dependency-policy.json
+++ b/build/dependency-policy.json
@@ -583,8 +583,7 @@
       "assemblyName": "Microsoft.Extensions.Logging.Abstractions",
       "classification": "block",
       "sourceModules": [
-        "MicrosoftTeams",
-        "Az.Resources"
+        "MicrosoftTeams"
       ],
       "updateMode": "reportOnly",
       "reason": "#193: paired with DependencyInjection.Abstractions (depends on it); same incidental-transitive collision with Az modules. Excluded from the bundle (ExcludeAssets=runtime).",
@@ -593,7 +592,7 @@
         "basis": "Excluded alongside DependencyInjection.Abstractions in 2.0.2. Microsoft.IdentityModel.Tokens still loads without it bundled (resolves lazily / supplied by the consuming service modules).",
         "decidedOn": "2026-05-31",
         "issue": "193",
-        "trackingScope": "Az.Resources is included in monitoredModules so upstream inventory captures this assembly family from the observed #193 collision source. #193 remains a DLLPickle-bundle-vs-consumer collision (not a cross-module version split), so the cross-module conflict-surface gate still may not flag every change by itself; preserve the regression guard against re-bundling in tests/Integration/DLLPickle.IntegrationTest.Tests.ps1 and re-adjudicate runtime behavior when Az.Resources dependency content changes."
+        "trackingScope": "Az.Resources does not ship this assembly; the refreshed inventory observes Microsoft.Extensions.Logging.Abstractions only in MicrosoftTeams (a single shipper, so it does not diverge cross-module and is not in the conflict surface). It is excluded from the bundle as the paired dependency of Microsoft.Extensions.DependencyInjection.Abstractions, which Az.Resources does ship and which is now monitored and present in the conflict surface. #193 remains a DLLPickle-bundle-vs-consumer collision; preserve the regression guard against re-bundling in tests/Integration/DLLPickle.IntegrationTest.Tests.ps1 and re-adjudicate runtime behavior when Az.Resources dependency content changes."
       }
     },
     {

--- a/build/dependency-policy.json
+++ b/build/dependency-policy.json
@@ -26,6 +26,11 @@
       "name": "MicrosoftTeams",
       "repository": "PSGallery",
       "purpose": "Teams identity stack compatibility source."
+    },
+    {
+      "name": "Az.Resources",
+      "repository": "PSGallery",
+      "purpose": "Observed #193 collision source for Microsoft.Extensions.* transitive assemblies."
     }
   ],
   "trackedAssemblies": [
@@ -72,13 +77,14 @@
     ]
   },
   "baseline": {
-    "capturedOn": "2026-06-23",
+    "capturedOn": "2026-06-25",
     "moduleVersions": {
       "Az.Accounts": "5.5.0",
       "Microsoft.Graph.Authentication": "2.38.0",
       "ExchangeOnlineManagement": "3.10.0",
       "MicrosoftTeams": "7.8.0",
-      "Az.Storage": "9.7.0"
+      "Az.Storage": "9.7.0",
+      "Az.Resources": "10.0.0"
     },
     "conflictSurfaceFingerprint": "8489ef99f7a87bd12c048e0f680bcdfc4a76eb736dcb093a732f83c66858f52c",
     "conflictSurface": [
@@ -558,7 +564,7 @@
         "basis": "Diagnostic 2026-05-31: DLLPickle preloaded 8.0.0 into the default ALC; PowerShell ships only Microsoft.Extensions.ObjectPool (not this); Az.Resources 9.x bundles its own copy -> 'assembly with same name is already loaded' on Import-Module Az.Resources. Fixed in 2.0.2.",
         "decidedOn": "2026-05-31",
         "issue": "193",
-        "trackingScope": "Az.Resources is the observed #193 collision trigger but is NOT in monitoredModules, so the drift inventory does not see its copy or future drift. Among the monitored modules, the current inventory observes this assembly only in MicrosoftTeams (a single shipper, so it does not diverge cross-module and is not in the conflict surface). #193 was a DLLPickle-bundle-vs-consumer collision, not a cross-module version split, so the cross-module drift gate does not model it; the regression guard against re-bundling this transitive lives in tests/Integration/DLLPickle.IntegrationTest.Tests.ps1. Re-adjudicate manually if a future Az.Resources change is suspected, or add Az.Resources to monitoredModules to inventory it directly."
+        "trackingScope": "Az.Resources is included in monitoredModules so upstream inventory captures this assembly family from the observed #193 collision source. #193 remains a DLLPickle-bundle-vs-consumer collision (not a cross-module version split), so the cross-module conflict-surface gate still may not flag every change by itself; preserve the regression guard against re-bundling in tests/Integration/DLLPickle.IntegrationTest.Tests.ps1 and re-adjudicate runtime behavior when Az.Resources dependency content changes."
       }
     },
     {
@@ -576,7 +582,7 @@
         "basis": "Excluded alongside DependencyInjection.Abstractions in 2.0.2. Microsoft.IdentityModel.Tokens still loads without it bundled (resolves lazily / supplied by the consuming service modules).",
         "decidedOn": "2026-05-31",
         "issue": "193",
-        "trackingScope": "Az.Resources is the observed #193 collision trigger but is NOT in monitoredModules, so the drift inventory does not see its copy or future drift. Among the monitored modules, the current inventory observes this assembly only in MicrosoftTeams (a single shipper, so it does not diverge cross-module and is not in the conflict surface). #193 was a DLLPickle-bundle-vs-consumer collision, not a cross-module version split, so the cross-module drift gate does not model it; the regression guard against re-bundling this transitive lives in tests/Integration/DLLPickle.IntegrationTest.Tests.ps1. Re-adjudicate manually if a future Az.Resources change is suspected, or add Az.Resources to monitoredModules to inventory it directly."
+        "trackingScope": "Az.Resources is included in monitoredModules so upstream inventory captures this assembly family from the observed #193 collision source. #193 remains a DLLPickle-bundle-vs-consumer collision (not a cross-module version split), so the cross-module conflict-surface gate still may not flag every change by itself; preserve the regression guard against re-bundling in tests/Integration/DLLPickle.IntegrationTest.Tests.ps1 and re-adjudicate runtime behavior when Az.Resources dependency content changes."
       }
     },
     {

--- a/build/dependency-policy.json
+++ b/build/dependency-policy.json
@@ -86,7 +86,7 @@
       "Az.Storage": "9.7.0",
       "Az.Resources": "10.0.0"
     },
-    "conflictSurfaceFingerprint": "8489ef99f7a87bd12c048e0f680bcdfc4a76eb736dcb093a732f83c66858f52c",
+    "conflictSurfaceFingerprint": "03b94d1603f2d7af09021a738fe9b7ed028dd18bba361e55bbe866bb1febaae0",
     "conflictSurface": [
       {
         "name": "Azure.Core",
@@ -120,6 +120,17 @@
         "shippedBy": [
           "Az.Accounts",
           "Microsoft.Graph.Authentication"
+        ]
+      },
+      {
+        "name": "Microsoft.Extensions.DependencyInjection.Abstractions",
+        "versions": [
+          "2.2.0.0",
+          "8.0.0.0"
+        ],
+        "shippedBy": [
+          "Az.Resources",
+          "MicrosoftTeams"
         ]
       },
       {

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -67,7 +67,7 @@ Every tracked assembly is classified into exactly one of:
 | `Microsoft.Identity.Client` (+ `.Broker`, `.Extensions.Msal`, `.NativeInterop`); `Microsoft.IdentityModel.*`; `System.IdentityModel.Tokens.Jwt` | **preload** | Default-ALC consumers (EXO/Teams) + the #156 broker fix; 2.0.1-validated. |
 | `Azure.Core`, `Azure.Identity`, `Azure.Identity.Broker`, `System.ClientModel` | **block** | Az + Graph self-isolate these privately; preloading splits type identity (the `Connect-AzAccount` break). **ALC-capable runtimes only** — would flip to `preload` on net48 (see §2 caveat / §10). |
 | `Microsoft.OData.Core`, `Microsoft.OData.Edm`, `Microsoft.Spatial` | **block** (report-only) | #174 — preloading breaks Az.Storage. |
-| `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions` | **block** | #193 — incidental `Microsoft.IdentityModel.Tokens` transitives, not host-provided. Preloading DLLPickle's own copies into the default ALC collided with the copies `Az.Resources` bundles (`assembly with same name is already loaded`). Excluded via `ExcludeAssets="runtime"` (shipped 2.0.2); `Microsoft.IdentityModel.Tokens` still loads without them. |
+| `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions` | **block** | #193 — incidental `Microsoft.IdentityModel.Tokens` transitives, not host-provided. Preloading DLLPickle's own copies into the default ALC collided with the copies `Az.Resources` bundles (`assembly with same name is already loaded`). Excluded via `ExcludeAssets="runtime"` (shipped 2.0.2); `Microsoft.IdentityModel.Tokens` still loads without them. `Az.Resources` is now explicitly monitored so drift inventory sees that collision source directly. |
 
 ## 4. Component map (authoritative paths)
 
@@ -191,7 +191,7 @@ Detailed status for open and in-progress maintenance traps is tracked in the [ga
 
 | Gap | Status | Architecture note |
 | --- | --- | --- |
-| [GAP-002](gaps/GAP-002-az-resources-monitoring.md) | open | `Az.Resources` is the observed #193 collision source but is not currently in `monitoredModules`. |
+| [GAP-002](gaps/GAP-002-az-resources-monitoring.md) | resolved | `Az.Resources` is now included in `monitoredModules`; policy tracking scope and dependency docs were updated with structural test coverage. |
 | [GAP-003](gaps/GAP-003-exo-teams-probe-commands.md) | open | EXO/Teams ALC ownership is not yet captured because bare `Import-Module` does not eagerly load their identity assemblies. |
 | [GAP-004](gaps/GAP-004-vscode-powershelleditorservices-host.md) | open | VS Code / PowerShellEditorServices host behavior is not yet modeled for issue #169. |
 | [GAP-005](gaps/GAP-005-odata-conflict-expectation-management.md) | open | OData/#174 remains a known unsolved single-process incompatibility; guard expectations and user docs must stay current. |

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -108,6 +108,10 @@ Monitored modules:
 - `Az.Storage`
 - `Az.Accounts`
 - `MicrosoftTeams`
+- `Az.Resources`
+
+`Az.Resources` is monitored explicitly because it is the observed collision
+source for the #193 `Microsoft.Extensions.*` transitive-assembly conflict.
 
 The workflow is fail-closed: it only opens a candidate PR after inventory,
 candidate generation, restore, build, and issue reproduction tests pass.

--- a/docs/Deep-Dive.md
+++ b/docs/Deep-Dive.md
@@ -102,6 +102,10 @@ The monitored module set currently includes:
 - `Az.Storage`
 - `Az.Accounts`
 - `MicrosoftTeams`
+- `Az.Resources`
+
+`Az.Resources` is monitored explicitly because it is the observed trigger for
+the #193 `Microsoft.Extensions.*` collision family.
 
 The workflow is fail-closed. It may open a candidate PR when a policy-supported
 pin changes, such as a Graph or Teams `Azure.Core` update. It does not merge or

--- a/docs/gaps/GAP-002-az-resources-monitoring.md
+++ b/docs/gaps/GAP-002-az-resources-monitoring.md
@@ -67,4 +67,4 @@ The repository either monitors `Az.Resources` directly or documents a deliberate
 
 Structural guardrails were added in `tests/Unit/DependencyPolicy.Tests.ps1` to enforce the monitoring decision and preserve `Az.Resources`-linked blocked-transitive expectations.
 
-Documentation was updated in `docs/DEPENDENCIES.md`, `docs/Deep-Dive.md`, and `docs/Architecture.md` so monitored-module lifecycle guidance and architecture notes align with the policy decision.
+Documentation was updated in `docs/DEPENDENCIES.md` so monitored-module lifecycle guidance aligns with the policy decision.

--- a/docs/gaps/GAP-002-az-resources-monitoring.md
+++ b/docs/gaps/GAP-002-az-resources-monitoring.md
@@ -9,14 +9,15 @@ created: 2026-06-23
 updated: 2026-06-25
 related_issues:
   - "193"
-related_prs: []
+related_prs:
+  - https://github.com/SamErde/DLLPickle/pull/264
 related_docs:
   - docs/Architecture.md
   - build/dependency-policy.json
   - docs/DEPENDENCIES.md
 related_tests:
   - tests/Integration/DLLPickle.IntegrationTest.Tests.ps1
-resolution_pr: pending-local-pr
+resolution_pr: https://github.com/SamErde/DLLPickle/pull/264
 resolved_on: 2026-06-25
 ---
 

--- a/docs/gaps/GAP-002-az-resources-monitoring.md
+++ b/docs/gaps/GAP-002-az-resources-monitoring.md
@@ -1,12 +1,12 @@
 ---
 id: GAP-002
 title: Track Az.Resources as a monitored collision source
-status: open
+status: resolved
 severity: high
 area: dependency-policy
 owner: maintainer
 created: 2026-06-23
-updated: 2026-06-23
+updated: 2026-06-25
 related_issues:
   - "193"
 related_prs: []
@@ -16,15 +16,15 @@ related_docs:
   - docs/DEPENDENCIES.md
 related_tests:
   - tests/Integration/DLLPickle.IntegrationTest.Tests.ps1
-resolution_pr:
-resolved_on:
+resolution_pr: pending-local-pr
+resolved_on: 2026-06-25
 ---
 
-# GAP-002 — Track Az.Resources as a monitored collision source
+## GAP-002 — Track Az.Resources as a monitored collision source
 
 ## Status
 
-**Current status:** Open.
+**Current status:** Resolved.
 
 ## Problem
 
@@ -46,12 +46,12 @@ The repository either monitors `Az.Resources` directly or documents a deliberate
 
 ## Acceptance criteria
 
-- [ ] Decide whether `Az.Resources` should be added to `monitoredModules`.
-- [ ] If added, update `build/dependency-policy.json` and refresh the baseline/fingerprint using the established upstream inventory process.
-- [ ] If not added, document the rationale and compensating guard in this gap and `docs/Architecture.md`.
-- [ ] Update or add tests so future workflow/policy changes preserve the decision.
-- [ ] Update `docs/DEPENDENCIES.md` if the monitored-module lifecycle changes.
-- [ ] Update `docs/gaps/README.md` and this file when resolved or superseded.
+- [x] Decide whether `Az.Resources` should be added to `monitoredModules`.
+- [x] If added, update `build/dependency-policy.json` and refresh the baseline/fingerprint using the established upstream inventory process.
+- [x] If not added, document the rationale and compensating guard in this gap and `docs/Architecture.md`.
+- [x] Update or add tests so future workflow/policy changes preserve the decision.
+- [x] Update `docs/DEPENDENCIES.md` if the monitored-module lifecycle changes.
+- [x] Update `docs/gaps/README.md` and this file when resolved or superseded.
 
 ## Implementation notes for Codex
 
@@ -63,4 +63,8 @@ The repository either monitors `Az.Resources` directly or documents a deliberate
 
 ## Resolution notes
 
-Pending.
+`Az.Resources` was added to `monitoredModules` in `build/dependency-policy.json`, with baseline capture metadata refreshed and #193 tracking-scope notes updated to reflect direct monitoring.
+
+Structural guardrails were added in `tests/Unit/DependencyPolicy.Tests.ps1` to enforce the monitoring decision and preserve `Az.Resources`-linked blocked-transitive expectations.
+
+Documentation was updated in `docs/DEPENDENCIES.md`, `docs/Deep-Dive.md`, and `docs/Architecture.md` so monitored-module lifecycle guidance and architecture notes align with the policy decision.

--- a/docs/gaps/README.md
+++ b/docs/gaps/README.md
@@ -34,7 +34,7 @@ Use this register for durable repo-local gap state. Use `docs/superpowers/specs/
 
 | ID | Status | Area | Title | File |
 | --- | --- | --- | --- | --- |
-| GAP-002 | open | dependency-policy | Track Az.Resources as a monitored collision source | [GAP-002](GAP-002-az-resources-monitoring.md) |
+| GAP-002 | resolved | dependency-policy | Track Az.Resources as a monitored collision source | [GAP-002](GAP-002-az-resources-monitoring.md) |
 | GAP-003 | open | runtime-probes | Add representative EXO and Teams probe commands | [GAP-003](GAP-003-exo-teams-probe-commands.md) |
 | GAP-004 | open | host-context | Model VS Code and PowerShellEditorServices host behavior | [GAP-004](GAP-004-vscode-powershelleditorservices-host.md) |
 | GAP-005 | open | known-conflicts | Strengthen OData conflict expectation management | [GAP-005](GAP-005-odata-conflict-expectation-management.md) |

--- a/tests/Unit/DependencyPolicy.Tests.ps1
+++ b/tests/Unit/DependencyPolicy.Tests.ps1
@@ -66,10 +66,10 @@ Describe 'Dependency policy baseline' -Tag 'Unit' {
         }
     }
 
-    It 'records the pull request 257 adjudication evidence' {
-        $script:Policy.baseline.validation.pullRequest | Should -Be 257
+    It 'records the pull request 264 adjudication evidence' {
+        $script:Policy.baseline.validation.pullRequest | Should -Be 264
         $script:Policy.baseline.validation.result | Should -BeExactly 'tracked-conflict-classified-and-excluded'
-        $script:Policy.baseline.validation.validatedOn | Should -BeExactly '2026-06-23'
+        $script:Policy.baseline.validation.validatedOn | Should -BeExactly '2026-06-25'
         @($script:Policy.baseline.validation.evidence) | Should -Not -BeNullOrEmpty
     }
 

--- a/tests/Unit/DependencyPolicy.Tests.ps1
+++ b/tests/Unit/DependencyPolicy.Tests.ps1
@@ -5,19 +5,28 @@ BeforeAll {
 
 Describe 'Dependency policy baseline' -Tag 'Unit' {
     It 'explicitly monitors Az.Resources as the #193 collision source' {
-        $MonitoredNames = @($script:Policy.monitoredModules | ForEach-Object name)
+        $MonitoredNames = @($script:Policy.monitoredModules.name)
         $MonitoredNames | Should -Contain 'Az.Resources'
 
-        $TrackedBlocked = @(
+        # Az.Resources ships Microsoft.Extensions.DependencyInjection.Abstractions (a diverging
+        # member of the conflict surface), so it must be recorded as a source module there.
+        $DiEntry = @(
             $script:Policy.blockedPreloadAssemblies |
-                Where-Object { $_.assemblyName -in @('Microsoft.Extensions.DependencyInjection.Abstractions', 'Microsoft.Extensions.Logging.Abstractions') }
+                Where-Object { $_.assemblyName -eq 'Microsoft.Extensions.DependencyInjection.Abstractions' }
         )
+        $DiEntry | Should -HaveCount 1
+        @($DiEntry[0].sourceModules) | Should -Contain 'Az.Resources'
+        $DiEntry[0].evidence.trackingScope | Should -Match 'included in monitoredModules'
 
-        $TrackedBlocked | Should -HaveCount 2
-        foreach ($Entry in $TrackedBlocked) {
-            @($Entry.sourceModules) | Should -Contain 'Az.Resources'
-            $Entry.evidence.trackingScope | Should -Match 'included in monitoredModules'
-        }
+        # Az.Resources does NOT ship Microsoft.Extensions.Logging.Abstractions; the refreshed
+        # inventory observes it only in MicrosoftTeams, so it must not be recorded there.
+        $LoggingEntry = @(
+            $script:Policy.blockedPreloadAssemblies |
+                Where-Object { $_.assemblyName -eq 'Microsoft.Extensions.Logging.Abstractions' }
+        )
+        $LoggingEntry | Should -HaveCount 1
+        @($LoggingEntry[0].sourceModules) | Should -Contain 'MicrosoftTeams'
+        @($LoggingEntry[0].sourceModules) | Should -Not -Contain 'Az.Resources'
     }
 
     It 'records the complete structured conflict surface' {

--- a/tests/Unit/DependencyPolicy.Tests.ps1
+++ b/tests/Unit/DependencyPolicy.Tests.ps1
@@ -30,7 +30,7 @@ Describe 'Dependency policy baseline' -Tag 'Unit' {
     }
 
     It 'records the complete structured conflict surface' {
-            @($script:Policy.baseline.conflictSurface) | Should -HaveCount 18
+        @($script:Policy.baseline.conflictSurface) | Should -HaveCount 18
 
         foreach ($Row in $script:Policy.baseline.conflictSurface) {
             $Row.name | Should -Not -BeNullOrEmpty

--- a/tests/Unit/DependencyPolicy.Tests.ps1
+++ b/tests/Unit/DependencyPolicy.Tests.ps1
@@ -9,14 +9,15 @@ Describe 'Dependency policy baseline' -Tag 'Unit' {
         $MonitoredNames | Should -Contain 'Az.Resources'
 
         # Az.Resources ships Microsoft.Extensions.DependencyInjection.Abstractions (a diverging
-        # member of the conflict surface), so it must be recorded as a source module there.
+        # member of the conflict surface), so it must be recorded as a source module there and
+        # carry the structured #193 collision linkage.
         $DiEntry = @(
             $script:Policy.blockedPreloadAssemblies |
                 Where-Object { $_.assemblyName -eq 'Microsoft.Extensions.DependencyInjection.Abstractions' }
         )
         $DiEntry | Should -HaveCount 1
         @($DiEntry[0].sourceModules) | Should -Contain 'Az.Resources'
-        $DiEntry[0].evidence.trackingScope | Should -Match 'included in monitoredModules'
+        $DiEntry[0].evidence.issue | Should -Be '193'
 
         # Az.Resources does NOT ship Microsoft.Extensions.Logging.Abstractions; the refreshed
         # inventory observes it only in MicrosoftTeams, so it must not be recorded there.

--- a/tests/Unit/DependencyPolicy.Tests.ps1
+++ b/tests/Unit/DependencyPolicy.Tests.ps1
@@ -4,6 +4,22 @@ BeforeAll {
 }
 
 Describe 'Dependency policy baseline' -Tag 'Unit' {
+    It 'explicitly monitors Az.Resources as the #193 collision source' {
+        $MonitoredNames = @($script:Policy.monitoredModules | ForEach-Object name)
+        $MonitoredNames | Should -Contain 'Az.Resources'
+
+        $TrackedBlocked = @(
+            $script:Policy.blockedPreloadAssemblies |
+                Where-Object { $_.assemblyName -in @('Microsoft.Extensions.DependencyInjection.Abstractions', 'Microsoft.Extensions.Logging.Abstractions') }
+        )
+
+        $TrackedBlocked | Should -HaveCount 2
+        foreach ($Entry in $TrackedBlocked) {
+            @($Entry.sourceModules) | Should -Contain 'Az.Resources'
+            $Entry.evidence.trackingScope | Should -Match 'included in monitoredModules'
+        }
+    }
+
     It 'records the complete structured conflict surface' {
         @($script:Policy.baseline.conflictSurface) | Should -HaveCount 17
 
@@ -57,4 +73,5 @@ Describe 'Dependency policy baseline' -Tag 'Unit' {
         @($ConflictRow[0].shippedBy) | Should -Be @('Az.Accounts', 'ExchangeOnlineManagement', 'Microsoft.Graph.Authentication', 'MicrosoftTeams')
         $BlockEntry | Should -HaveCount 1
     }
+
 }

--- a/tests/Unit/DependencyPolicy.Tests.ps1
+++ b/tests/Unit/DependencyPolicy.Tests.ps1
@@ -21,7 +21,7 @@ Describe 'Dependency policy baseline' -Tag 'Unit' {
     }
 
     It 'records the complete structured conflict surface' {
-        @($script:Policy.baseline.conflictSurface) | Should -HaveCount 17
+            @($script:Policy.baseline.conflictSurface) | Should -HaveCount 18
 
         foreach ($Row in $script:Policy.baseline.conflictSurface) {
             $Row.name | Should -Not -BeNullOrEmpty
@@ -51,7 +51,7 @@ Describe 'Dependency policy baseline' -Tag 'Unit' {
             @($script:Policy.blockedPreloadAssemblies).assemblyName
         )
 
-        $ConflictNames | Should -HaveCount 17
+        $ConflictNames | Should -HaveCount 18
         foreach ($Name in $ConflictNames) {
             @($ClassifiedNames | Where-Object { $_ -eq $Name }) | Should -HaveCount 1
         }


### PR DESCRIPTION
## Summary
- add `Az.Resources` to monitored modules in `build/dependency-policy.json`
- refresh baseline metadata and module versions for drift tracking scope
- add unit guardrails in `tests/Unit/DependencyPolicy.Tests.ps1` to enforce #193 tracking expectations
- update architecture/dependency/gap docs to reflect resolved GAP-002 status

## Why
GAP-002 required making `Az.Resources` an explicit monitored collision source so upstream drift tooling can observe #193-related `Microsoft.Extensions.*` transitive changes directly.

## Validation
- targeted policy/unit validation was run locally during implementation and reached pass state before branch split

## Gap linkage
- resolves GAP-002 (`docs/gaps/GAP-002-az-resources-monitoring.md`)
- leaves GAP-005 open for the follow-up PR by design
