### PR TITLE
test(gaps): add gap-register structural guard (GAP-011)

### DIFF
--- a/.github/prompts/maintain-gap.prompt.md
+++ b/.github/prompts/maintain-gap.prompt.md
@@ -65,3 +65,9 @@ Summarize:
 - [ ] Related docs are updated or explicitly left unchanged with rationale.
 - [ ] Relevant tests were added or updated when practical.
 - [ ] Validation commands were run or a clear blocker is documented.
+
+## Automated register guard
+
+`tests/Unit/GapRegister.Tests.ps1` enforces the structural parts of this workflow: allowed `status` values, gap-file-to-index membership, index/frontmatter status agreement, and `resolution_pr`/`resolved_on` presence on `resolved` gaps. Run `Invoke-Build -Task Test -File build/DLLPickle.Build.ps1` (or the focused Pester file) after editing any gap file or the index.
+
+The guard is intentionally structural only. Confirming that a resolved gap's `related_docs` were actually updated stays a **review-only** responsibility — do not treat a green guard run as proof the documentation was synchronized.

--- a/.github/workflows/Build Module.yml
+++ b/.github/workflows/Build Module.yml
@@ -73,7 +73,10 @@ jobs:
               $Files = gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[] | .filename, (.previous_filename // empty)'
               # Native non-zero exits don't reliably throw in pwsh, so check explicitly -> fail-safe.
               if ($LASTEXITCODE -ne 0) { throw "gh api exited $LASTEXITCODE while listing PR files" }
-              $Patterns = @('^src/', '^build/', '^tests/', '^tools/', '^\.github/ci-scripts/', '^\.github/workflows/Build Module\.yml$')
+              # docs/gaps/ is build-relevant: the gap-register guard (tests/Unit/GapRegister.Tests.ps1)
+              # must run when gap files or their index change, otherwise a docs-only gap edit would skip
+              # the very check that detects gap-register drift (GAP-011).
+              $Patterns = @('^src/', '^build/', '^tests/', '^tools/', '^docs/gaps/', '^\.github/ci-scripts/', '^\.github/workflows/Build Module\.yml$')
               $Relevant = $false
               foreach ($File in $Files) {
                   foreach ($Pattern in $Patterns) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Working on updates to replace PlatyPS documentation creation with the new Microsoft.PowerShell.PlatyPS module. (PRs and other help would be welcomed!)
+- Added a structural gap-register guard (`tests/Unit/GapRegister.Tests.ps1`) that validates gap status values, index membership, index/frontmatter status agreement, and `resolution_pr`/`resolved_on` on resolved gaps; surfaced and fixed GAP-001's missing index row (GAP-011).
 
 ## [2.2.2] - 2026-06-22
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -198,6 +198,7 @@ Detailed status for open and in-progress maintenance traps is tracked in the [ga
 | [GAP-006](gaps/GAP-006-release-dispatch-process-trap.md) | open | Packaging/release-logic changes may require deliberate `workflow_dispatch` because non-bundle paths do not auto-publish. |
 | [GAP-007](gaps/GAP-007-required-status-check-ruleset-audit.md) | open | Required status-check ruleset configuration lives partly outside the repository and needs an auditable repo-local snapshot or procedure. |
 | [GAP-008](gaps/GAP-008-manifest-export-drift.md) | open | Manifest `FunctionsToExport` should be guarded against drift from intended public functions. |
+| [GAP-011](gaps/GAP-011-docs-implementation-drift.md) | resolved | Gap register status/index/resolution drift is guarded by `tests/Unit/GapRegister.Tests.ps1`; related-docs updates remain review-only. |
 
 Historical/resolved notes remain below when they explain the current architecture or release contract.
 

--- a/docs/gaps/GAP-011-docs-implementation-drift.md
+++ b/docs/gaps/GAP-011-docs-implementation-drift.md
@@ -16,7 +16,7 @@ related_docs:
   - docs/superpowers/specs
 related_tests:
   - tests/Unit/GapRegister.Tests.ps1
-resolution_pr: pending-local-pr
+resolution_pr: https://github.com/SamErde/DLLPickle/pull/266
 resolved_on: 2026-06-26
 ---
 

--- a/docs/gaps/GAP-011-docs-implementation-drift.md
+++ b/docs/gaps/GAP-011-docs-implementation-drift.md
@@ -1,12 +1,12 @@
 ---
 id: GAP-011
 title: Guard docs and implementation drift for gap closures
-status: open
+status: resolved
 severity: medium
 area: documentation
 owner: maintainer
 created: 2026-06-23
-updated: 2026-06-23
+updated: 2026-06-26
 related_issues: []
 related_prs: []
 related_docs:
@@ -14,16 +14,17 @@ related_docs:
   - docs/gaps/README.md
   - docs/superpowers/plans
   - docs/superpowers/specs
-related_tests: []
-resolution_pr:
-resolved_on:
+related_tests:
+  - tests/Unit/GapRegister.Tests.ps1
+resolution_pr: pending-local-pr
+resolved_on: 2026-06-26
 ---
 
 # GAP-011 — Guard docs and implementation drift for gap closures
 
 ## Status
 
-**Current status:** Open.
+**Current status:** Resolved.
 
 ## Problem
 
@@ -44,12 +45,12 @@ The repository has either a lightweight automated consistency check for gap file
 
 ## Acceptance criteria
 
-- [ ] Add a structural test or script that validates gap frontmatter status values.
-- [ ] Add a structural test or script that checks every `docs/gaps/GAP-*.md` file appears in `docs/gaps/README.md`.
-- [ ] Add a structural test or script that checks resolved gaps include `resolution_pr` and `resolved_on`.
-- [ ] Decide whether related docs updates can be tested structurally or must remain review-only.
-- [ ] Update `.github/prompts/maintain-gap.prompt.md` if the workflow changes.
-- [ ] Update `docs/gaps/README.md` and this file when resolved or superseded.
+- [x] Add a structural test or script that validates gap frontmatter status values.
+- [x] Add a structural test or script that checks every `docs/gaps/GAP-*.md` file appears in `docs/gaps/README.md`.
+- [x] Add a structural test or script that checks resolved gaps include `resolution_pr` and `resolved_on`.
+- [x] Decide whether related docs updates can be tested structurally or must remain review-only.
+- [x] Update `.github/prompts/maintain-gap.prompt.md` if the workflow changes.
+- [x] Update `docs/gaps/README.md` and this file when resolved or superseded.
 
 ## Implementation notes for Codex
 
@@ -60,4 +61,6 @@ The repository has either a lightweight automated consistency check for gap file
 
 ## Resolution notes
 
-Pending.
+Added `tests/Unit/GapRegister.Tests.ps1`, a deterministic, local-only Pester guard that validates: allowed `status` values, gap-file-to-index membership, index/frontmatter status agreement, and `resolution_pr`/`resolved_on` presence on resolved gaps. Implementing the guard surfaced existing drift: GAP-001 (resolved) was missing from the index and is now listed.
+
+Decision on related-docs updates: kept **review-only**. Verifying that a resolved gap's `related_docs` were meaningfully updated cannot be done structurally without false positives, so it remains a maintainer/agent review responsibility documented in `docs/gaps/README.md` and `.github/prompts/maintain-gap.prompt.md`.

--- a/docs/gaps/README.md
+++ b/docs/gaps/README.md
@@ -34,6 +34,7 @@ Use this register for durable repo-local gap state. Use `docs/superpowers/specs/
 
 | ID | Status | Area | Title | File |
 | --- | --- | --- | --- | --- |
+| GAP-001 | resolved | dependency-policy | Add dependency policy realization guard | [GAP-001](GAP-001-dependency-policy-realization-guard.md) |
 | GAP-002 | resolved | dependency-policy | Track Az.Resources as a monitored collision source | [GAP-002](GAP-002-az-resources-monitoring.md) |
 | GAP-003 | open | runtime-probes | Add representative EXO and Teams probe commands | [GAP-003](GAP-003-exo-teams-probe-commands.md) |
 | GAP-004 | open | host-context | Model VS Code and PowerShellEditorServices host behavior | [GAP-004](GAP-004-vscode-powershelleditorservices-host.md) |
@@ -43,7 +44,7 @@ Use this register for durable repo-local gap state. Use `docs/superpowers/specs/
 | GAP-008 | open | module-manifest | Guard manifest export drift | [GAP-008](GAP-008-manifest-export-drift.md) |
 | GAP-009 | open | build-output | Make merged root-module script order deterministic | [GAP-009](GAP-009-merged-root-module-order.md) |
 | GAP-010 | open | review-process | Define unresolved review-thread maintenance workflow | [GAP-010](GAP-010-unresolved-review-thread-maintenance.md) |
-| GAP-011 | open | documentation | Guard docs and implementation drift for gap closures | [GAP-011](GAP-011-docs-implementation-drift.md) |
+| GAP-011 | resolved | documentation | Guard docs and implementation drift for gap closures | [GAP-011](GAP-011-docs-implementation-drift.md) |
 
 ## Agent workflow
 
@@ -54,3 +55,14 @@ Use this register for durable repo-local gap state. Use `docs/superpowers/specs/
 5. Add or update tests before marking a gap resolved when an automated guard is practical.
 6. Update related documentation before finalizing the PR.
 7. Update this index and the gap file frontmatter in the same PR that resolves, blocks, supersedes, or intentionally accepts the gap.
+
+## Automated guard
+
+`tests/Unit/GapRegister.Tests.ps1` structurally validates this register on every unit-test run. It fails the build when:
+
+- a `GAP-*.md` file declares a `status` outside the allowed values above,
+- a `GAP-*.md` file is missing from the gap index table,
+- a gap file's frontmatter status does not match its index row, or
+- a `resolved` gap is missing `resolution_pr` or `resolved_on`.
+
+The guard is deterministic and local-only; it does not call the GitHub API. Whether the `related_docs` of a resolved gap were actually updated remains a **review-only** check, because that cannot be verified structurally without false positives.

--- a/tests/Unit/GapRegister.Tests.ps1
+++ b/tests/Unit/GapRegister.Tests.ps1
@@ -1,0 +1,89 @@
+﻿BeforeDiscovery {
+    $gapProjectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+    $gapDirectory = Join-Path $gapProjectRoot 'docs\gaps'
+
+    function Get-GapFrontmatterField {
+        param(
+            [string] $Frontmatter,
+            [string] $Field
+        )
+
+        $fieldMatch = [regex]::Match($Frontmatter, "(?m)^$([regex]::Escape($Field)):\s*(.*)$")
+        if (-not $fieldMatch.Success) {
+            return $null
+        }
+
+        return $fieldMatch.Groups[1].Value.Trim()
+    }
+
+    # Parse every gap file's frontmatter once at discovery so -ForEach can fan out per gap.
+    $GapFiles = @(
+        Get-ChildItem -LiteralPath $gapDirectory -Filter 'GAP-*.md' -File |
+            Sort-Object -Property Name |
+            ForEach-Object {
+                $content = Get-Content -LiteralPath $_.FullName -Raw
+                $frontmatterMatch = [regex]::Match($content, '(?s)^---\s*\r?\n(.*?)\r?\n---')
+                $frontmatter = if ($frontmatterMatch.Success) { $frontmatterMatch.Groups[1].Value } else { '' }
+
+                # Emit a hashtable so Pester's -ForEach expands keys into per-test variables.
+                @{
+                    Name         = $_.Name
+                    Id           = Get-GapFrontmatterField -Frontmatter $frontmatter -Field 'id'
+                    Status       = Get-GapFrontmatterField -Frontmatter $frontmatter -Field 'status'
+                    ResolutionPr = Get-GapFrontmatterField -Frontmatter $frontmatter -Field 'resolution_pr'
+                    ResolvedOn   = Get-GapFrontmatterField -Frontmatter $frontmatter -Field 'resolved_on'
+                }
+            }
+    )
+
+    $ResolvedGapFiles = @($GapFiles | Where-Object { $_.Status -eq 'resolved' })
+}
+
+BeforeAll {
+    $projectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+    $indexPath = Join-Path $projectRoot 'docs\gaps\README.md'
+
+    # Status values must stay in sync with the status table in docs/gaps/README.md.
+    $script:AllowedGapStatuses = @('open', 'in-progress', 'blocked', 'resolved', 'superseded', 'wont-fix')
+
+    # Parse the index table rows (| GAP-### | status | ... |) into a lookup.
+    $indexContent = Get-Content -LiteralPath $indexPath -Raw
+    $script:GapIndexRows = @{}
+    foreach ($line in ($indexContent -split '\r?\n')) {
+        $rowMatch = [regex]::Match($line, '^\|\s*(GAP-\d+)\s*\|\s*([^|]+?)\s*\|')
+        if ($rowMatch.Success) {
+            $script:GapIndexRows[$rowMatch.Groups[1].Value] = $rowMatch.Groups[2].Value.Trim()
+        }
+    }
+}
+
+Describe 'Gap register consistency' -Tag 'Unit' {
+    Context 'Frontmatter for <Name>' -ForEach $GapFiles {
+        It 'declares an id that matches its file name' {
+            $Id | Should -Not -BeNullOrEmpty
+            $Name | Should -BeLike "$Id-*"
+        }
+
+        It 'uses an allowed status value' {
+            $Status | Should -BeIn $script:AllowedGapStatuses
+        }
+
+        It 'appears as a row in the gap index' {
+            $script:GapIndexRows.ContainsKey($Id) | Should -BeTrue
+        }
+
+        It 'has an index status matching its frontmatter status' {
+            $script:GapIndexRows[$Id] | Should -Be $Status
+        }
+    }
+
+    Context 'Resolved gap <Name>' -ForEach $ResolvedGapFiles {
+        It 'records a resolution_pr' {
+            $ResolutionPr | Should -Not -BeNullOrEmpty
+        }
+
+        It 'records a resolved_on date' {
+            $ResolvedOn | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Unit/GapRegister.Tests.ps1
+++ b/tests/Unit/GapRegister.Tests.ps1
@@ -1,4 +1,4 @@
-﻿BeforeDiscovery {
+BeforeDiscovery {
     $gapProjectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
     $gapDirectory = Join-Path $gapProjectRoot 'docs\gaps'
 
@@ -69,10 +69,17 @@ Describe 'Gap register consistency' -Tag 'Unit' {
         }
 
         It 'appears as a row in the gap index' {
+            # Assert the id is present first so a missing-id gap fails with an actionable message
+            # instead of ContainsKey($null) throwing an ArgumentNullException.
+            $Id | Should -Not -BeNullOrEmpty -Because 'a gap file without an id cannot be matched to an index row'
             $script:GapIndexRows.ContainsKey($Id) | Should -BeTrue
         }
 
         It 'has an index status matching its frontmatter status' {
+            # Guard both lookup inputs so a missing id/status reports the real defect rather than
+            # silently comparing $null index values.
+            $Id | Should -Not -BeNullOrEmpty -Because 'a gap file without an id cannot be looked up in the index'
+            $Status | Should -Not -BeNullOrEmpty -Because 'the index status comparison needs a frontmatter status'
             $script:GapIndexRows[$Id] | Should -Be $Status
         }
     }


### PR DESCRIPTION
## Summary

Resolves **GAP-011** (guard docs/implementation drift for gap closures) by adding a structural, local-only guard over the gap register.

## Changes

- **New test** `tests/Unit/GapRegister.Tests.ps1` — validates, for every `docs/gaps/GAP-*.md`:
  - `id` frontmatter matches the filename,
  - `status` is one of the allowed values (`open`/`in-progress`/`blocked`/`resolved`/`superseded`/`wont-fix`),
  - the gap appears in the `docs/gaps/README.md` index table,
  - the index status matches the frontmatter status, and
  - `resolved` gaps record both `resolution_pr` and `resolved_on`.
- **Drift fix** — the guard surfaced that **GAP-001** (resolved) was missing from the register index; added its row.
- **Docs** — documented the guard in `docs/gaps/README.md` (new "Automated guard" section) and `.github/prompts/maintain-gap.prompt.md`; recorded GAP-011 as resolved in the index and `docs/Architecture.md` §10.

## Scope notes

- The guard is deterministic and does **not** call the GitHub API. Whether a resolved gap's `related_docs` were actually updated remains a **review-only** check (cannot be verified structurally without false positives).
- This is the standalone half of the hybrid split; GAP-006 + GAP-010 are submitted in a separate PR.

## Validation

- `tests/Unit/GapRegister.Tests.ps1` — 52/52 passing.
