### PR TITLE
docs(release): document release-dispatch trap and review-thread workflow (GAP-006, GAP-010)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Working on updates to replace PlatyPS documentation creation with the new Microsoft.PowerShell.PlatyPS module. (PRs and other help would be welcomed!)
+- Documented the manual release dispatch process trap: Architecture §8.3 now spells out which changes auto-publish, which do not, and when a deliberate `workflow_dispatch` run is required, backed by new `Release-and-Publish` path/version-gate guardrail tests (GAP-006).
+- Documented the unresolved review-thread maintenance workflow so review threads are not resolved as a substitute for code, test, or documentation changes (GAP-010).
 
 ## [2.2.2] - 2026-06-22
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -160,6 +160,32 @@ A release that fails either half is not TFM-aligned and must not be merged on th
 
 This mirrors the **hard gate** in §9: bundle-set changes are behavior-changing and require the auth-tier real-environment sign-off; they are not auto-merged blindly.
 
+### 8.3 Manual release dispatch (maintainer runbook)
+
+The path gate in §8.1 is deliberate: a merge only auto-publishes when it changes the **published bundle** (`src/DLLPickle/**`, `src/DLLPickle.Build/DLLPickle.csproj`, or `src/DLLPickle.Build/packages.lock.json`). This protects the gallery from docs/CI/test/tooling churn, but it creates a **process trap**: a change that is *about* releasing or packaging — yet does not touch a bundle path — will merge without ever publishing. A maintainer (or agent) can reasonably but wrongly assume "merged" means "shipped".
+
+**Does this merge auto-publish?**
+
+| Change | Auto-publishes? | Why |
+| --- | --- | --- |
+| Edit a public/private function under `src/DLLPickle/**` | ✅ Yes (with a release-worthy commit prefix) | Hits the path gate; the version gate fires on `feat:`/`fix:`/etc. |
+| Dependabot NuGet bump (`DLLPickle.csproj` + `packages.lock.json`, `deps:` prefix) | ✅ Yes → **minor** | Path gate ✔ + `deps:` is a recognized minor prefix (§8.1/§8.2). |
+| Edit `build/DLLPickle.Build.ps1` packaging/release logic | ❌ No | `build/**` is excluded from the `paths:` filter — bundle bytes are unchanged. |
+| Edit `.github/workflows/Release-and-Publish.yml` | ❌ No | `.github/**` is excluded. |
+| Edit `build/dependency-policy.json`, tests, tooling, or docs only | ❌ No | None of these change the shipped DLLs or module source. |
+| Any bundle-path change whose commits are all `docs:`/`ci:`/`style:` | ❌ No | Path gate ✔ but the version gate finds no release-worthy prefix. |
+
+**When `workflow_dispatch` is the correct tool.** Use the manual **Run workflow** button on `Release-and-Publish` (the deliberate-release escape hatch) when **all** of the following hold:
+
+1. The change should ship a new gallery version, **and**
+2. It does **not** move a bundle path (so the automatic path gate will never fire) — for example a packaging/release-logic fix in `build/DLLPickle.Build.ps1`, **or**
+3. You need to re-release after a transient publish failure (the failed run rolls back by deleting the tag/release; `main` is never committed to), **or**
+4. You are cutting a release whose bump type you want to set explicitly (`major`/`minor`/`patch`) rather than inferring from commit prefixes (`auto`).
+
+**When *not* to use it.** Do not use `workflow_dispatch` to bypass the version gate for ordinary code changes — fix the commit prefix instead. Do not manually dispatch a release for docs/CI/test/tooling-only changes; by design they do not ship a new module version.
+
+> **Agent guidance:** never report that a non-bundle change (build script, workflow, policy, tests, tooling, docs) has "shipped" or "published" simply because its PR merged. State that it merged and, if a release is intended, that a deliberate `workflow_dispatch` run is required. The path gate and version gate are guarded by `tests/Unit/WorkflowGuardrails.Tests.ps1`.
+
 ## 9. Agent workstream conventions
 
 When changing the preload contract, follow this loop:
@@ -184,6 +210,30 @@ Issue #239 was adjudicated on 2026-06-20 against Microsoft.Graph.Authentication 
 - Commit/push only when the maintainer asks.
 - Never hand-edit `module/` (generated). Never weaken analyzer settings to silence a finding — fix the code or scope a justified suppression.
 - Do not mark a `docs/gaps/GAP-*.md` item `resolved` unless the implementation, tests or explicit test rationale, and documentation updates are complete and linked.
+- Do not resolve a pull-request review thread as a substitute for code, test, or documentation changes (see §9.1).
+
+### 9.1 Review-thread maintenance workflow
+
+The `Protect Main` ruleset expects review-thread resolution before merge (this is the conversation-resolution half of GAP-007's required-status posture). That gate is only meaningful if threads are resolved because the underlying concern was addressed — not to clear a merge blocker. This workflow is intentionally kept **separate** from GAP-007: GAP-007 audits the *ruleset configuration*; this section governs *human/agent behavior* on threads.
+
+**Who may resolve a thread.** Prefer the reviewer who opened it. An author (human or agent) may resolve a thread only when the change that addresses it is committed and linked, or when the thread is non-actionable (answered question, acknowledged nit, or out-of-scope item tracked elsewhere).
+
+**Resolve a thread only when one of these is true:**
+
+1. The requested change is implemented and the resolving commit is referenced in a reply, **or**
+2. The concern is answered with a substantive reply and the reviewer agrees (or explicitly deferred to author discretion), **or**
+3. The item is out of scope and is captured as a `docs/gaps/GAP-*.md` entry or a linked issue, referenced in the reply.
+
+**Do not:**
+
+- Resolve a thread without a reply explaining how it was addressed.
+- Bulk-resolve threads to unblock a merge.
+- Resolve a thread by deleting or weakening the code, test, or doc it asked about.
+- Treat thread resolution as equivalent to closing the work — if a thread maps to deferred work, open or update a gap and link it.
+
+**Stale threads.** If a thread is stale because the surrounding code changed, reply with the superseding commit/PR and resolve. If it is stale because of an unmade decision, leave it open and request maintainer review rather than resolving silently.
+
+**Agent guidance.** Agents must never resolve review threads autonomously to make a PR mergeable. An agent may *reply* to a thread describing the change it made and may resolve only under rule (1) above with the commit linked; otherwise it leaves the thread for maintainer action.
 
 ## 10. Known gaps / follow-ups
 
@@ -195,9 +245,10 @@ Detailed status for open and in-progress maintenance traps is tracked in the [ga
 | [GAP-003](gaps/GAP-003-exo-teams-probe-commands.md) | open | EXO/Teams ALC ownership is not yet captured because bare `Import-Module` does not eagerly load their identity assemblies. |
 | [GAP-004](gaps/GAP-004-vscode-powershelleditorservices-host.md) | open | VS Code / PowerShellEditorServices host behavior is not yet modeled for issue #169. |
 | [GAP-005](gaps/GAP-005-odata-conflict-expectation-management.md) | resolved | OData/#174 expectation management is explicit in known-conflict data, docs, and policy tests; changes require runtime re-adjudication. |
-| [GAP-006](gaps/GAP-006-release-dispatch-process-trap.md) | open | Packaging/release-logic changes may require deliberate `workflow_dispatch` because non-bundle paths do not auto-publish. |
+| [GAP-006](gaps/GAP-006-release-dispatch-process-trap.md) | resolved | The manual release dispatch runbook (§8.3) documents which changes auto-publish and when `workflow_dispatch` is required; guarded by `tests/Unit/WorkflowGuardrails.Tests.ps1`. |
 | [GAP-007](gaps/GAP-007-required-status-check-ruleset-audit.md) | open | Required status-check ruleset configuration lives partly outside the repository and needs an auditable repo-local snapshot or procedure. |
 | [GAP-008](gaps/GAP-008-manifest-export-drift.md) | open | Manifest `FunctionsToExport` should be guarded against drift from intended public functions. |
+| [GAP-010](gaps/GAP-010-unresolved-review-thread-maintenance.md) | resolved | Review-thread maintenance workflow is documented in §9.1; kept separate from GAP-007 (configuration audit) by design. |
 
 Historical/resolved notes remain below when they explain the current architecture or release contract.
 

--- a/docs/gaps/GAP-006-release-dispatch-process-trap.md
+++ b/docs/gaps/GAP-006-release-dispatch-process-trap.md
@@ -15,7 +15,7 @@ related_docs:
   - .github/workflows/Release-and-Publish.yml
 related_tests:
   - tests/Unit/WorkflowGuardrails.Tests.ps1
-resolution_pr: pending-local-pr
+resolution_pr: https://github.com/SamErde/DLLPickle/pull/267
 resolved_on: 2026-06-26
 ---
 

--- a/docs/gaps/GAP-006-release-dispatch-process-trap.md
+++ b/docs/gaps/GAP-006-release-dispatch-process-trap.md
@@ -1,12 +1,12 @@
 ---
 id: GAP-006
 title: Document manual release dispatch process trap
-status: open
+status: resolved
 severity: medium
 area: release-process
 owner: maintainer
 created: 2026-06-23
-updated: 2026-06-23
+updated: 2026-06-26
 related_issues: []
 related_prs: []
 related_docs:
@@ -15,15 +15,15 @@ related_docs:
   - .github/workflows/Release-and-Publish.yml
 related_tests:
   - tests/Unit/WorkflowGuardrails.Tests.ps1
-resolution_pr:
-resolved_on:
+resolution_pr: pending-local-pr
+resolved_on: 2026-06-26
 ---
 
 # GAP-006 — Document manual release dispatch process trap
 
 ## Status
 
-**Current status:** Open.
+**Current status:** Resolved.
 
 ## Problem
 
@@ -45,12 +45,12 @@ The repository contains clear maintainer-facing instructions for when and how to
 
 ## Acceptance criteria
 
-- [ ] Add a maintainer-facing release dispatch note to `docs/Architecture.md`, `CHANGELOG.md`, or a dedicated release document.
-- [ ] Document examples of changes that do and do not publish automatically.
-- [ ] Document when `workflow_dispatch` is appropriate.
-- [ ] Confirm workflow guardrail tests cover the path gate and manual-dispatch expectations where practical.
-- [ ] Update PR/release guidance so Codex does not claim that non-bundle changes are shipped automatically.
-- [ ] Update `docs/gaps/README.md` and this file when resolved or superseded.
+- [x] Add a maintainer-facing release dispatch note to `docs/Architecture.md`, `CHANGELOG.md`, or a dedicated release document.
+- [x] Document examples of changes that do and do not publish automatically.
+- [x] Document when `workflow_dispatch` is appropriate.
+- [x] Confirm workflow guardrail tests cover the path gate and manual-dispatch expectations where practical.
+- [x] Update PR/release guidance so Codex does not claim that non-bundle changes are shipped automatically.
+- [x] Update `docs/gaps/README.md` and this file when resolved or superseded.
 
 ## Implementation notes for Codex
 
@@ -62,4 +62,6 @@ The repository contains clear maintainer-facing instructions for when and how to
 
 ## Resolution notes
 
-Pending.
+Added a maintainer runbook as `docs/Architecture.md` §8.3 ("Manual release dispatch"), including a "Does this merge auto-publish?" table of concrete examples, the precise conditions under which `workflow_dispatch` is the correct tool, when not to use it, and explicit agent guidance never to claim a non-bundle change "shipped" just because its PR merged. Recorded the change in `CHANGELOG.md` under Unreleased.
+
+The release path gate and the `workflow_dispatch` escape hatch are now guarded by `tests/Unit/WorkflowGuardrails.Tests.ps1` (`Release publish gating guardrails`): it asserts the `paths:` filter contains exactly the three bundle inputs, that non-bundle paths (`docs/**`, `tests/**`, `tools/**`, `build/**`) are not path-gated, and that `workflow_dispatch` exposes the explicit `auto/major/minor/patch` bump choice. The publish triggers were not broadened.

--- a/docs/gaps/GAP-010-unresolved-review-thread-maintenance.md
+++ b/docs/gaps/GAP-010-unresolved-review-thread-maintenance.md
@@ -11,7 +11,7 @@ related_issues: []
 related_prs: []
 related_docs:
   - docs/Architecture.md
-  - .github/workflows/Build-Module.yml
+  - .github/workflows/Build Module.yml
 related_tests: []
 resolution_pr: https://github.com/SamErde/DLLPickle/pull/267
 resolved_on: 2026-06-26

--- a/docs/gaps/GAP-010-unresolved-review-thread-maintenance.md
+++ b/docs/gaps/GAP-010-unresolved-review-thread-maintenance.md
@@ -13,7 +13,7 @@ related_docs:
   - docs/Architecture.md
   - .github/workflows/Build-Module.yml
 related_tests: []
-resolution_pr: pending-local-pr
+resolution_pr: https://github.com/SamErde/DLLPickle/pull/267
 resolved_on: 2026-06-26
 ---
 

--- a/docs/gaps/GAP-010-unresolved-review-thread-maintenance.md
+++ b/docs/gaps/GAP-010-unresolved-review-thread-maintenance.md
@@ -1,27 +1,27 @@
 ---
 id: GAP-010
 title: Define unresolved review-thread maintenance workflow
-status: open
+status: resolved
 severity: low
 area: review-process
 owner: maintainer
 created: 2026-06-23
-updated: 2026-06-23
+updated: 2026-06-26
 related_issues: []
 related_prs: []
 related_docs:
   - docs/Architecture.md
   - .github/workflows/Build-Module.yml
 related_tests: []
-resolution_pr:
-resolved_on:
+resolution_pr: pending-local-pr
+resolved_on: 2026-06-26
 ---
 
 # GAP-010 — Define unresolved review-thread maintenance workflow
 
 ## Status
 
-**Current status:** Open.
+**Current status:** Resolved.
 
 ## Problem
 
@@ -42,11 +42,11 @@ The repository documents how maintainers and agents should handle unresolved rev
 
 ## Acceptance criteria
 
-- [ ] Decide whether this gap should be folded into GAP-007 or kept separate.
-- [ ] Document the review-thread maintenance workflow if kept separate.
-- [ ] Update the relevant PR guidance or architecture note.
-- [ ] Ensure the workflow does not encourage agents to resolve review threads without addressing the underlying issue.
-- [ ] Update `docs/gaps/README.md` and this file when resolved, superseded, or folded into GAP-007.
+- [x] Decide whether this gap should be folded into GAP-007 or kept separate.
+- [x] Document the review-thread maintenance workflow if kept separate.
+- [x] Update the relevant PR guidance or architecture note.
+- [x] Ensure the workflow does not encourage agents to resolve review threads without addressing the underlying issue.
+- [x] Update `docs/gaps/README.md` and this file when resolved, superseded, or folded into GAP-007.
 
 ## Implementation notes for Codex
 
@@ -57,4 +57,6 @@ The repository documents how maintainers and agents should handle unresolved rev
 
 ## Resolution notes
 
-Pending.
+Decision: **kept separate** from GAP-007. GAP-007 audits the required-status-check *ruleset configuration*; this gap governs *human and agent behavior* on review threads, so folding them would conflate a configuration audit with a process convention.
+
+Documented the workflow in `docs/Architecture.md` §9.1 ("Review-thread maintenance workflow"): who may resolve a thread, the three conditions under which a thread may be resolved, an explicit do-not list, stale-thread handling, and agent-specific guidance. Added a matching hard-gate bullet to §9 stating that resolving a thread is never a substitute for code, test, or documentation changes, and that threads mapping to deferred work must be captured as a `GAP-*` entry or linked issue.

--- a/docs/gaps/README.md
+++ b/docs/gaps/README.md
@@ -38,11 +38,11 @@ Use this register for durable repo-local gap state. Use `docs/superpowers/specs/
 | GAP-003 | open | runtime-probes | Add representative EXO and Teams probe commands | [GAP-003](GAP-003-exo-teams-probe-commands.md) |
 | GAP-004 | open | host-context | Model VS Code and PowerShellEditorServices host behavior | [GAP-004](GAP-004-vscode-powershelleditorservices-host.md) |
 | GAP-005 | resolved | known-conflicts | Strengthen OData conflict expectation management | [GAP-005](GAP-005-odata-conflict-expectation-management.md) |
-| GAP-006 | open | release-process | Document manual release dispatch process trap | [GAP-006](GAP-006-release-dispatch-process-trap.md) |
+| GAP-006 | resolved | release-process | Document manual release dispatch process trap | [GAP-006](GAP-006-release-dispatch-process-trap.md) |
 | GAP-007 | open | branch-protection | Audit required status-check ruleset configuration | [GAP-007](GAP-007-required-status-check-ruleset-audit.md) |
 | GAP-008 | open | module-manifest | Guard manifest export drift | [GAP-008](GAP-008-manifest-export-drift.md) |
 | GAP-009 | open | build-output | Make merged root-module script order deterministic | [GAP-009](GAP-009-merged-root-module-order.md) |
-| GAP-010 | open | review-process | Define unresolved review-thread maintenance workflow | [GAP-010](GAP-010-unresolved-review-thread-maintenance.md) |
+| GAP-010 | resolved | review-process | Define unresolved review-thread maintenance workflow | [GAP-010](GAP-010-unresolved-review-thread-maintenance.md) |
 | GAP-011 | open | documentation | Guard docs and implementation drift for gap closures | [GAP-011](GAP-011-docs-implementation-drift.md) |
 
 ## Agent workflow

--- a/tests/Unit/WorkflowGuardrails.Tests.ps1
+++ b/tests/Unit/WorkflowGuardrails.Tests.ps1
@@ -2,6 +2,7 @@ BeforeAll {
     $ProjectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
     $UpstreamWorkflow = Get-Content -LiteralPath (Join-Path $ProjectRoot '.github\workflows\Upstream-Compatibility.yml') -Raw
     $DependabotWorkflow = Get-Content -LiteralPath (Join-Path $ProjectRoot '.github\workflows\Dependabot-Auto-Approve.yml') -Raw
+    $ReleaseWorkflow = Get-Content -LiteralPath (Join-Path $ProjectRoot '.github\workflows\Release-and-Publish.yml') -Raw
 }
 
 Describe 'Upstream compatibility workflow guardrails' -Tag 'Unit' {
@@ -68,5 +69,32 @@ Describe 'Dependabot major-version draft-PR flow' -Tag 'Unit' {
         # Auto-merge is invoked exactly once -- in the patch/minor step, never on the major path.
         ([regex]::Matches($DependabotWorkflow, [regex]::Escape('gh pr merge --auto'))).Count | Should -Be 1
         $DependabotWorkflow | Should -Match ([regex]::Escape("update-type != 'version-update:semver-major'"))
+    }
+}
+
+Describe 'Release publish gating guardrails' -Tag 'Unit' {
+    It 'auto-triggers only on closed pull requests to main' {
+        $ReleaseWorkflow | Should -Match '(?ms)on:\s+pull_request:\s+types:\s*\[closed\]'
+        $ReleaseWorkflow | Should -Match '(?ms)branches:\s+- main'
+    }
+
+    It 'path-gates auto-publish to the three bundle-affecting inputs' {
+        $ReleaseWorkflow | Should -Match ([regex]::Escape('- "src/DLLPickle/**"'))
+        $ReleaseWorkflow | Should -Match ([regex]::Escape('- "src/DLLPickle.Build/DLLPickle.csproj"'))
+        $ReleaseWorkflow | Should -Match ([regex]::Escape('- "src/DLLPickle.Build/packages.lock.json"'))
+    }
+
+    It 'does not path-gate on non-bundle inputs that must never auto-publish' {
+        # docs/test/tooling/policy/CI-only changes leave the shipped bundle byte-identical.
+        $ReleaseWorkflow | Should -Not -Match '(?m)^\s+- "docs/\*\*"'
+        $ReleaseWorkflow | Should -Not -Match '(?m)^\s+- "tests/\*\*"'
+        $ReleaseWorkflow | Should -Not -Match '(?m)^\s+- "tools/\*\*"'
+        $ReleaseWorkflow | Should -Not -Match '(?m)^\s+- "build/\*\*"'
+    }
+
+    It 'exposes workflow_dispatch as the deliberate-release escape hatch with an explicit bump choice' {
+        $ReleaseWorkflow | Should -Match '(?m)^\s+workflow_dispatch:'
+        $ReleaseWorkflow | Should -Match ([regex]::Escape('version_bump'))
+        $ReleaseWorkflow | Should -Match '(?ms)options:\s+- auto\s+- major\s+- minor\s+- patch'
     }
 }

--- a/tests/Unit/WorkflowGuardrails.Tests.ps1
+++ b/tests/Unit/WorkflowGuardrails.Tests.ps1
@@ -85,12 +85,22 @@ Describe 'Release publish gating guardrails' -Tag 'Unit' {
         # GAP-006 is closed to prevent. The list must therefore have no entries beyond the allow-list.
         $pathsMatch = [regex]::Match(
             $ReleaseWorkflow,
-            '(?ms)^  pull_request:.*?^    paths:\r?\n(?<list>(?:[^\S\r\n]+-[^\S\r\n].*(?:\r?\n|$))+)')
+            '(?m)^  pull_request:[\s\S]*?^    paths:\r?\n(?<list>(?:[^\S\r\n]+-[^\S\r\n][^\r\n]*\r?\n?)+)')
         $pathsMatch.Success | Should -BeTrue -Because 'the pull_request trigger must declare a paths allow-list'
 
+        # Extract every YAML sequence item under paths: regardless of quote style (double-quoted,
+        # single-quoted, or unquoted) so an extra entry like - docs/** or - 'docs/**' is still
+        # captured and trips the EXACTLY-three assertion instead of being silently ignored.
         $declaredPaths = @(
-            [regex]::Matches($pathsMatch.Groups['list'].Value, '(?m)^[^\S\r\n]+-[^\S\r\n]+"(?<path>[^"]+)"') |
-                ForEach-Object { $_.Groups['path'].Value }
+            $pathsMatch.Groups['list'].Value -split '\r?\n' |
+                ForEach-Object {
+                    $item = [regex]::Match($_, '^[^\S\r\n]*-[^\S\r\n]+(?<path>\S.*?)[^\S\r\n]*$')
+                    if ($item.Success) {
+                        # Strip one matching pair of surrounding double or single quotes, if present.
+                        $item.Groups['path'].Value -replace '^"(.*)"$', '$1' -replace "^'(.*)'`$", '$1'
+                    }
+                } |
+                Where-Object { $_ }
         )
         $allowedPaths = @(
             'src/DLLPickle/**'

--- a/tests/Unit/WorkflowGuardrails.Tests.ps1
+++ b/tests/Unit/WorkflowGuardrails.Tests.ps1
@@ -78,10 +78,26 @@ Describe 'Release publish gating guardrails' -Tag 'Unit' {
         $ReleaseWorkflow | Should -Match '(?ms)branches:\s+- main'
     }
 
-    It 'path-gates auto-publish to the three bundle-affecting inputs' {
-        $ReleaseWorkflow | Should -Match ([regex]::Escape('- "src/DLLPickle/**"'))
-        $ReleaseWorkflow | Should -Match ([regex]::Escape('- "src/DLLPickle.Build/DLLPickle.csproj"'))
-        $ReleaseWorkflow | Should -Match ([regex]::Escape('- "src/DLLPickle.Build/packages.lock.json"'))
+    It 'path-gates auto-publish to EXACTLY the three bundle-affecting inputs' {
+        # Parse the pull_request paths: allow-list and assert it is EXACTLY the three bundle inputs.
+        # A presence-only check would still pass if an accidental auto-publish path (e.g. "docs/**",
+        # "*.md", ".github/**") were added later -- the precise CI/docs release-trigger regression
+        # GAP-006 is closed to prevent. The list must therefore have no entries beyond the allow-list.
+        $pathsMatch = [regex]::Match(
+            $ReleaseWorkflow,
+            '(?ms)^  pull_request:.*?^    paths:\r?\n(?<list>(?:[^\S\r\n]+-[^\S\r\n].*(?:\r?\n|$))+)')
+        $pathsMatch.Success | Should -BeTrue -Because 'the pull_request trigger must declare a paths allow-list'
+
+        $declaredPaths = @(
+            [regex]::Matches($pathsMatch.Groups['list'].Value, '(?m)^[^\S\r\n]+-[^\S\r\n]+"(?<path>[^"]+)"') |
+                ForEach-Object { $_.Groups['path'].Value }
+        )
+        $allowedPaths = @(
+            'src/DLLPickle/**'
+            'src/DLLPickle.Build/DLLPickle.csproj'
+            'src/DLLPickle.Build/packages.lock.json'
+        )
+        $declaredPaths | Should -Be $allowedPaths
     }
 
     It 'does not path-gate on non-bundle inputs that must never auto-publish' {


### PR DESCRIPTION
## Summary

Resolves **GAP-006** (document the manual release-dispatch process trap) and **GAP-010** (define the unresolved review-thread maintenance workflow). These are combined because both are release/process documentation hardening with a shared Architecture surface.

## GAP-006 — release-dispatch process trap

- **Architecture §8.3 "Manual release dispatch (maintainer runbook)"** — explains why the path gate exists, a "Does this merge auto-publish?" decision table, exactly when `workflow_dispatch` is the correct tool, when *not* to use it, and explicit agent guidance to never claim a non-bundle change "shipped" just because its PR merged.
- **`tests/Unit/WorkflowGuardrails.Tests.ps1`** — new `Release-and-Publish` guardrails asserting the workflow auto-triggers on a closed PR to `main`, path-gates to the three bundle paths only (not docs/tests/tooling/build), and exposes a `workflow_dispatch` bump input (`auto`/`major`/`minor`/`patch`).

## GAP-010 — review-thread maintenance workflow

- **Architecture §9.1 "Review-thread maintenance workflow"** — who may resolve a thread, the three conditions under which a thread may be resolved, an explicit do-not list, stale-thread handling, and agent guidance.
- **§9 hard-gate bullet** — resolving a review thread is never a substitute for code, test, or documentation changes.
- Kept **separate** from GAP-007 by design: GAP-007 audits the *ruleset configuration*; this governs *human/agent behavior* on threads.

## Register

- Marked GAP-006 and GAP-010 `resolved` in `docs/gaps/README.md` and `docs/Architecture.md` §10.
- The structural gap-register guard lands in the companion PR (#266); the index/frontmatter changes here are consistent with it in either merge order.

## Validation

- `tests/Unit/WorkflowGuardrails.Tests.ps1` — 15/15 passing.
