### PR TITLE
test(gaps): validate gap index File-column link basenames

### DIFF
--- a/docs/gaps/README.md
+++ b/docs/gaps/README.md
@@ -63,6 +63,7 @@ Use this register for durable repo-local gap state. Use `docs/superpowers/specs/
 - a `GAP-*.md` file declares a `status` outside the allowed values above,
 - a `GAP-*.md` file is missing from the gap index table,
 - a gap file's frontmatter status does not match its index row, or
+- a gap index row File-column link basename does not match its actual `GAP-*.md` filename, or
 - a `resolved` gap is missing `resolution_pr` or `resolved_on`.
 
 The guard is deterministic and local-only; it does not call the GitHub API. Whether the `related_docs` of a resolved gap were actually updated remains a **review-only** check, because that cannot be verified structurally without false positives.

--- a/tests/Unit/GapRegister.Tests.ps1
+++ b/tests/Unit/GapRegister.Tests.ps1
@@ -46,13 +46,20 @@ BeforeAll {
     # Status values must stay in sync with the status table in docs/gaps/README.md.
     $script:AllowedGapStatuses = @('open', 'in-progress', 'blocked', 'resolved', 'superseded', 'wont-fix')
 
-    # Parse the index table rows (| GAP-### | status | ... |) into a lookup.
+    # Parse the index table rows (| GAP-### | status | ... | [GAP-###](GAP-###-file.md) |)
+    # into a lookup of index status + File-column link basename.
     $indexContent = Get-Content -LiteralPath $indexPath -Raw
     $script:GapIndexRows = @{}
     foreach ($line in ($indexContent -split '\r?\n')) {
-        $rowMatch = [regex]::Match($line, '^\|\s*(GAP-\d+)\s*\|\s*([^|]+?)\s*\|')
+        $rowMatch = [regex]::Match(
+            $line,
+            '^\|\s*(GAP-\d+)\s*\|\s*([^|]+?)\s*\|[^|]*\|[^|]*\|\s*\[[^\]]+\]\((?<file>[^)]+)\)\s*\|')
         if ($rowMatch.Success) {
-            $script:GapIndexRows[$rowMatch.Groups[1].Value] = $rowMatch.Groups[2].Value.Trim()
+            $gapId = $rowMatch.Groups[1].Value
+            $script:GapIndexRows[$gapId] = @{
+                Status = $rowMatch.Groups[2].Value.Trim()
+                File   = [System.IO.Path]::GetFileName($rowMatch.Groups['file'].Value.Trim())
+            }
         }
     }
 }
@@ -80,7 +87,13 @@ Describe 'Gap register consistency' -Tag 'Unit' {
             # silently comparing $null index values.
             $Id | Should -Not -BeNullOrEmpty -Because 'a gap file without an id cannot be looked up in the index'
             $Status | Should -Not -BeNullOrEmpty -Because 'the index status comparison needs a frontmatter status'
-            $script:GapIndexRows[$Id] | Should -Be $Status
+            $script:GapIndexRows[$Id].Status | Should -Be $Status
+        }
+
+        It 'has an index file link basename matching its file name' {
+            $Id | Should -Not -BeNullOrEmpty -Because 'a gap file without an id cannot be looked up in the index'
+            $script:GapIndexRows.ContainsKey($Id) | Should -BeTrue
+            $script:GapIndexRows[$Id].File | Should -Be $Name
         }
     }
 

--- a/tests/Unit/GapRegister.Tests.ps1
+++ b/tests/Unit/GapRegister.Tests.ps1
@@ -56,9 +56,13 @@ BeforeAll {
             '^\|\s*(GAP-\d+)\s*\|\s*([^|]+?)\s*\|[^|]*\|[^|]*\|\s*\[[^\]]+\]\((?<file>[^)]+)\)\s*\|')
         if ($rowMatch.Success) {
             $gapId = $rowMatch.Groups[1].Value
+            $fileLinkTarget = $rowMatch.Groups['file'].Value.Trim()
+            # Treat README link fragments/query as non-basename metadata (foo.md#x, foo.md?y)
+            # so this guard validates the file path basename only.
+            $filePathOnly = ($fileLinkTarget -split '[#?]', 2)[0]
             $script:GapIndexRows[$gapId] = @{
                 Status = $rowMatch.Groups[2].Value.Trim()
-                File   = [System.IO.Path]::GetFileName($rowMatch.Groups['file'].Value.Trim())
+                File   = [System.IO.Path]::GetFileName($filePathOnly)
             }
         }
     }
@@ -87,6 +91,7 @@ Describe 'Gap register consistency' -Tag 'Unit' {
             # silently comparing $null index values.
             $Id | Should -Not -BeNullOrEmpty -Because 'a gap file without an id cannot be looked up in the index'
             $Status | Should -Not -BeNullOrEmpty -Because 'the index status comparison needs a frontmatter status'
+            $script:GapIndexRows.ContainsKey($Id) | Should -BeTrue
             $script:GapIndexRows[$Id].Status | Should -Be $Status
         }
 


### PR DESCRIPTION
## Summary
- extend 	ests/Unit/GapRegister.Tests.ps1 to parse each gap-index File-column markdown link target
- assert the link target basename matches the actual GAP-*.md filename for that row
- update docs/gaps/README.md automated guard section to document the new enforced check

## Why
Follow-up from PR #266 review discussion r3481674186: current guard validated id/status but could miss a broken File-column link if id/status stayed unchanged.

## Validation
- 	ests/Unit/GapRegister.Tests.ps1 (67 passed)
- 	ests/Unit/WorkflowGuardrails.Tests.ps1 (15 passed)
